### PR TITLE
Use type keyword for type exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ coverage
 yarn.lock   
 
 # misc
-local-scripts/
+.local
 .idea
 .vscode
 src/webpack/__tests__/__fixtures__/webpack/output

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ export {
   getRouteContext,
 } from './common/utils';
 
-export {
+export type {
   Location,
   Route,
   Routes,
@@ -41,7 +41,7 @@ export {
   BrowserHistory,
 } from './common/types';
 
-export {
+export type {
   RouterActionsType,
   RouterActionPush,
   RouterActionReplace,


### PR DESCRIPTION
### Fixed 

* Type exports no longer make it into the `build/esm/index.js` file fixing a bug noticed when using the library in CRA apps