### PR TITLE
Ensure MemoryRouterProps is exported as a type correctly

### DIFF
--- a/src/common/utils/match-route/index.ts
+++ b/src/common/utils/match-route/index.ts
@@ -3,7 +3,6 @@ import { qs } from 'url-parse';
 import { Match, MatchedRoute, MatchParams, Query, Routes } from '../../types';
 
 import matchPath from './matchPath';
-// import type { Match, Route, MatchedRoute } from '../../types';
 
 /* This should match what react-router does to compute a root match. */
 const computeRootMatch = (pathname: string) => ({

--- a/src/controllers/memory-router/index.tsx
+++ b/src/controllers/memory-router/index.tsx
@@ -53,4 +53,4 @@ export const MemoryRouter = (props: MemoryRouterProps) => {
   );
 };
 
-export { MemoryRouterProps };
+export type { MemoryRouterProps };


### PR DESCRIPTION
### Fixed 

* `MemoryRouterProps` needed to be exported as a type using the keyword

### Removed 

* Commented out import in match-route util