### PR TITLE
Added universal-router controller

### DIFF
--- a/src/__tests__/unit/controllers/universal-router/test.tsx
+++ b/src/__tests__/unit/controllers/universal-router/test.tsx
@@ -1,0 +1,288 @@
+import React from 'react';
+
+import { mount } from 'enzyme';
+import * as historyHelper from 'history';
+import { mockRoute } from '../../../../common/mocks';
+import { UniversalRouter as Router } from '../../../../controllers/universal-router';
+import { RouterSubscriber } from '../../../../controllers/subscribers/route';
+import { getResourceStore } from '../../../../controllers/resource-store';
+import { defaultRegistry } from 'react-sweet-state';
+import { getRouterState } from '../../../../controllers/router-store';
+
+const mockLocation = {
+  pathname: '/pathname',
+  search: '?foo=bar',
+  hash: '#hash',
+};
+const mockHistory = {
+  push: jest.fn(),
+  replace: jest.fn(),
+  goBack: jest.fn(),
+  goForward: jest.fn(),
+  registerBlock: jest.fn(),
+  listen: jest.fn(),
+  createHref: jest.fn(),
+  location: mockLocation,
+};
+const expiresAt = null;
+const unlistenMock = jest.fn();
+const routes: any[] = [];
+
+describe('UniversalRouter', () => {
+  describe('Browser environment', () => {
+    beforeEach(() => {
+      mockHistory.listen.mockReturnValue(unlistenMock);
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    it('renders a RouterContainer', () => {
+      const wrapper = mount(
+        // @ts-ignore
+        <Router history={mockHistory} routes={routes}>
+          <div>hello</div>
+        </Router>
+      );
+
+      const component = wrapper.find('RouterContainer');
+
+      expect(component).toHaveLength(1);
+
+      expect(component.props()).toEqual(
+        expect.objectContaining({
+          history: mockHistory,
+          routes,
+        })
+      );
+    });
+
+    it('should call the history unlistener on unmount', () => {
+      const wrapper = mount(
+        // @ts-ignore
+        <Router history={mockHistory} routes={routes}>
+          <div>hello</div>
+        </Router>
+      );
+
+      wrapper.unmount();
+
+      expect(unlistenMock).toHaveBeenCalledTimes(1);
+    });
+
+    describe('when the router is re-mounted by a parent component', () => {
+      it('should clean up the original history listener', () => {
+        // @ts-ignore
+        const RemountingParent = ({ shouldRemount = false, children }) => {
+          if (shouldRemount) {
+            return <>{children}</>;
+          }
+
+          return <div>{children}</div>;
+        };
+        const newUnlistener = jest.fn();
+        const router = (
+          // @ts-ignore
+          <Router history={mockHistory} routes={routes}>
+            <div>hello</div>
+          </Router>
+        );
+        const wrapper = mount(<RemountingParent>{router}</RemountingParent>);
+
+        // first listener is created on mount
+        expect(mockHistory.listen).toHaveBeenCalledTimes(1);
+
+        mockHistory.listen.mockReturnValue(newUnlistener);
+
+        // trigger the re-mount
+        wrapper.setProps({ shouldRemount: true });
+
+        // second listener is created by the RouterContainer on re-mount
+        expect(mockHistory.listen).toHaveBeenCalledTimes(2);
+
+        // the original unlistener is called and the new one is not called
+        expect(unlistenMock).toHaveBeenCalledTimes(1);
+        expect(newUnlistener).toHaveBeenCalledTimes(0);
+      });
+    });
+  });
+
+  describe('Server environment', () => {
+    afterEach(() => {
+      defaultRegistry.stores.clear();
+      jest.resetAllMocks();
+      jest.restoreAllMocks();
+    });
+    beforeEach(() => {
+      jest
+        .spyOn(historyHelper, 'createMemoryHistory')
+        // @ts-ignore
+        .mockImplementation(() => mockHistory);
+    });
+
+    it('should not respond to history changes', () => {
+      mount(
+        <Router routes={[]}>
+          <RouterSubscriber>
+            {() => <div>I am a subscriber</div>}
+          </RouterSubscriber>
+        </Router>
+      );
+
+      expect(mockHistory.listen).not.toHaveBeenCalled();
+    });
+
+    describe('static requestResources', () => {
+      const type = 'type';
+      const key = 'key';
+      const result = 'result';
+      const resolver = (r: any, d = 0) =>
+        new Promise(resolve => setTimeout(() => resolve(r), d));
+      const getDataPromise = Promise.resolve(result);
+      const mockResource = {
+        type,
+        getKey: () => key,
+        getData: () => getDataPromise,
+      };
+      const mockedRoutes = [
+        {
+          ...mockRoute,
+          path: mockLocation.pathname,
+          component: () => <div>foo</div>,
+          resources: [
+            {
+              ...mockResource,
+              ...{ type: 'HI', getData: () => resolver('hello world', 250) },
+            },
+            {
+              ...mockResource,
+              ...{
+                type: 'BYE',
+                getData: () => resolver('goodbye cruel world', 500),
+              },
+            },
+          ],
+        },
+      ];
+
+      it('should expose a static requestResources method', () => {
+        expect(typeof Router.requestResources).toBe('function');
+      });
+
+      it('should return hydratable, cleaned resource store state.data when awaited', async () => {
+        const data = await Router.requestResources({
+          // @ts-ignore
+          routes: mockedRoutes,
+        });
+
+        expect(data).toEqual({
+          BYE: {
+            key: {
+              data: 'goodbye cruel world',
+              error: null,
+              loading: false,
+              promise: null,
+              expiresAt,
+            },
+          },
+          HI: {
+            key: {
+              data: 'hello world',
+              error: null,
+              loading: false,
+              promise: null,
+              expiresAt,
+            },
+          },
+        });
+      });
+
+      it('should maintain the pre-requested state in the resource store when mounted', async () => {
+        await Router.requestResources({
+          // @ts-ignore
+          routes: mockedRoutes,
+          location: '/',
+        });
+
+        const resourceData = {
+          BYE: {
+            key: {
+              data: 'goodbye cruel world',
+              error: null,
+              loading: false,
+              promise: null,
+              expiresAt,
+            },
+          },
+          HI: {
+            key: {
+              data: 'hello world',
+              error: null,
+              loading: false,
+              promise: null,
+              expiresAt,
+            },
+          },
+        };
+
+        mount(
+          <Router routes={[]}>
+            <RouterSubscriber>
+              {() => <div>I am a subscriber</div>}
+            </RouterSubscriber>
+          </Router>
+        );
+
+        expect(getResourceStore().actions.getSafeData()).toEqual(resourceData);
+      });
+
+      it('should not re-request resources on mount if resources have already been requested by requestResources', async () => {
+        const { pathname: location } = mockLocation;
+        const resourceSpy1 = jest.spyOn(
+          mockedRoutes[0].resources[0],
+          'getData'
+        );
+        const resourceSpy2 = jest.spyOn(
+          mockedRoutes[0].resources[1],
+          'getData'
+        );
+
+        await Router.requestResources({
+          // @ts-ignore
+          routes: mockedRoutes,
+          location,
+        });
+
+        mount(
+          <Router location={location} routes={[]}>
+            <RouterSubscriber>
+              {() => <div>I am a subscriber</div>}
+            </RouterSubscriber>
+          </Router>
+        );
+
+        expect(resourceSpy1).toHaveBeenCalledTimes(1);
+        expect(resourceSpy2).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  describe('Memory environment', () => {
+    afterEach(() => {
+      defaultRegistry.stores.clear();
+    });
+
+    it('should register an instance of memory history in the router store when mounted with a location set', () => {
+      mount(
+        <Router routes={[]} location={'/'}>
+          {'hello world'}
+        </Router>
+      );
+
+      const { history } = getRouterState();
+
+      expect(history).toHaveProperty('canGo');
+    });
+  });
+});

--- a/src/__tests__/unit/controllers/universal-router/test.tsx
+++ b/src/__tests__/unit/controllers/universal-router/test.tsx
@@ -8,6 +8,7 @@ import { RouterSubscriber } from '../../../../controllers/subscribers/route';
 import { getResourceStore } from '../../../../controllers/resource-store';
 import { defaultRegistry } from 'react-sweet-state';
 import { getRouterState } from '../../../../controllers/router-store';
+import { isNodeEnvironment } from '../../../../common/utils';
 
 const mockLocation = {
   pathname: '/pathname',
@@ -28,9 +29,15 @@ const expiresAt = null;
 const unlistenMock = jest.fn();
 const routes: any[] = [];
 
+jest.mock('../../../../common/utils', () => ({
+  ...jest.requireActual<any>('../../../../common/utils'),
+  isNodeEnvironment: jest.fn(),
+}));
+
 describe('UniversalRouter', () => {
   describe('Browser environment', () => {
     beforeEach(() => {
+      (isNodeEnvironment as any).mockImplementation(() => false);
       mockHistory.listen.mockReturnValue(unlistenMock);
     });
 
@@ -46,7 +53,7 @@ describe('UniversalRouter', () => {
         </Router>
       );
 
-      const component = wrapper.find('RouterContainer');
+      const component = wrapper.find('UniversalRouterContainer');
 
       expect(component).toHaveLength(1);
 

--- a/src/__tests__/unit/controllers/universal-router/test.tsx
+++ b/src/__tests__/unit/controllers/universal-router/test.tsx
@@ -6,8 +6,6 @@ import { mockRoute } from '../../../../common/mocks';
 import { UniversalRouter as Router } from '../../../../controllers/universal-router';
 import { RouterSubscriber } from '../../../../controllers/subscribers/route';
 import { getResourceStore } from '../../../../controllers/resource-store';
-import { defaultRegistry } from 'react-sweet-state';
-import { getRouterState } from '../../../../controllers/router-store';
 import { isServerEnvironment } from '../../../../common/utils';
 
 const mockLocation = {
@@ -117,7 +115,7 @@ describe('UniversalRouter', () => {
 
   describe('Server environment', () => {
     afterEach(() => {
-      defaultRegistry.stores.clear();
+      // defaultRegistry.stores.clear();
       jest.resetAllMocks();
       jest.restoreAllMocks();
     });
@@ -130,7 +128,7 @@ describe('UniversalRouter', () => {
 
     it('should not respond to history changes', () => {
       mount(
-        <Router routes={[]}>
+        <Router routes={[]} isGlobal={false}>
           <RouterSubscriber>
             {() => <div>I am a subscriber</div>}
           </RouterSubscriber>
@@ -234,7 +232,7 @@ describe('UniversalRouter', () => {
         };
 
         mount(
-          <Router routes={[]}>
+          <Router routes={[]} isGlobal={false}>
             <RouterSubscriber>
               {() => <div>I am a subscriber</div>}
             </RouterSubscriber>
@@ -262,7 +260,7 @@ describe('UniversalRouter', () => {
         });
 
         mount(
-          <Router location={location} routes={[]}>
+          <Router location={location} routes={[]} isGlobal={false}>
             <RouterSubscriber>
               {() => <div>I am a subscriber</div>}
             </RouterSubscriber>
@@ -276,20 +274,25 @@ describe('UniversalRouter', () => {
   });
 
   describe('Memory environment', () => {
-    afterEach(() => {
-      defaultRegistry.stores.clear();
-    });
-
     it('should register an instance of memory history in the router store when mounted with a location set', () => {
+      let memoryHistory;
+
       mount(
-        <Router routes={[]} location={'/'}>
-          {'hello world'}
+        <Router routes={[]} location={'/'} isGlobal={false}>
+          <RouterSubscriber>
+            {
+              /* @ts-ignore */
+              ({ history }) => {
+                memoryHistory = history;
+
+                return null;
+              }
+            }
+          </RouterSubscriber>
         </Router>
       );
 
-      const { history } = getRouterState();
-
-      expect(history).toHaveProperty('canGo');
+      expect(memoryHistory).toHaveProperty('canGo');
     });
   });
 });

--- a/src/__tests__/unit/controllers/universal-router/test.tsx
+++ b/src/__tests__/unit/controllers/universal-router/test.tsx
@@ -8,7 +8,7 @@ import { RouterSubscriber } from '../../../../controllers/subscribers/route';
 import { getResourceStore } from '../../../../controllers/resource-store';
 import { defaultRegistry } from 'react-sweet-state';
 import { getRouterState } from '../../../../controllers/router-store';
-import { isNodeEnvironment } from '../../../../common/utils';
+import { isServerEnvironment } from '../../../../common/utils';
 
 const mockLocation = {
   pathname: '/pathname',
@@ -31,13 +31,13 @@ const routes: any[] = [];
 
 jest.mock('../../../../common/utils', () => ({
   ...jest.requireActual<any>('../../../../common/utils'),
-  isNodeEnvironment: jest.fn(),
+  isServerEnvironment: jest.fn(),
 }));
 
 describe('UniversalRouter', () => {
   describe('Browser environment', () => {
     beforeEach(() => {
-      (isNodeEnvironment as any).mockImplementation(() => false);
+      (isServerEnvironment as any).mockImplementation(() => false);
       mockHistory.listen.mockReturnValue(unlistenMock);
     });
 

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -2,3 +2,4 @@ export { default as matchRoute } from './match-route';
 export { default as generatePath } from './generate-path';
 export { createLegacyHistory } from './history';
 export { getRouteContext } from './get-route-context';
+export { isNodeEnvironment } from './is-node-environment';

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -2,4 +2,4 @@ export { default as matchRoute } from './match-route';
 export { default as generatePath } from './generate-path';
 export { createLegacyHistory } from './history';
 export { getRouteContext } from './get-route-context';
-export { isNodeEnvironment } from './is-node-environment';
+export { isServerEnvironment } from './is-server-environment';

--- a/src/common/utils/is-node-environment/index.ts
+++ b/src/common/utils/is-node-environment/index.ts
@@ -1,0 +1,11 @@
+export const isNodeEnvironment = () => {
+  if (typeof window === 'undefined') {
+    return true;
+  }
+
+  if (window.name === 'nodejs') {
+    return true;
+  }
+
+  return false;
+};

--- a/src/common/utils/is-node-environment/index.ts
+++ b/src/common/utils/is-node-environment/index.ts
@@ -1,9 +1,18 @@
+/**
+ * @see https://github.com/jsdom/jsdom/releases/tag/12.0.0
+ * @see https://github.com/jsdom/jsdom/issues/1537
+ */
+const isJsDomEnvironment = () =>
+  window.name === 'nodejs' ||
+  navigator.userAgent.includes('Node.js') ||
+  navigator.userAgent.includes('jsdom');
+
 export const isNodeEnvironment = () => {
   if (typeof window === 'undefined') {
     return true;
   }
 
-  if (window.name === 'nodejs') {
+  if (isJsDomEnvironment()) {
     return true;
   }
 

--- a/src/common/utils/is-server-environment/index.ts
+++ b/src/common/utils/is-server-environment/index.ts
@@ -7,8 +7,12 @@ const isJsDomEnvironment = () =>
   navigator.userAgent.includes('Node.js') ||
   navigator.userAgent.includes('jsdom');
 
-export const isNodeEnvironment = () => {
-  if (typeof window === 'undefined') {
+export const isServerEnvironment = () => {
+  if (
+    typeof process !== 'undefined' &&
+    process.versions != null &&
+    process.versions.node != null
+  ) {
     return true;
   }
 

--- a/src/controllers/router-store/index.tsx
+++ b/src/controllers/router-store/index.tsx
@@ -14,7 +14,7 @@ import {
   DEFAULT_MATCH,
   DEFAULT_ROUTE,
 } from '../../common/constants';
-import { getRouteContext, isNodeEnvironment } from '../../common/utils';
+import { getRouteContext, isServerEnvironment } from '../../common/utils';
 import { getResourceStore } from '../resource-store';
 import { getResourcesForNextLocation } from '../resource-store/utils';
 
@@ -63,7 +63,7 @@ const actions: AllRouterActions = {
   },
 
   /**
-   * Duplicate method that uses isNodeEnvironment instead of removed isStatic prop
+   * Duplicate method that uses isServerEnvironment instead of removed isStatic prop
    * internally. We can remove this when UniversalRouter replaces Router completely.
    */
   bootstrapStoreUniversal: props => ({ setState, dispatch }) => {
@@ -79,7 +79,7 @@ const actions: AllRouterActions = {
     });
     getResourceStore().actions.hydrate({ resourceContext, resourceData });
 
-    if (!isNodeEnvironment()) {
+    if (!isServerEnvironment()) {
       dispatch(actions.listen());
     }
   },
@@ -239,7 +239,7 @@ export const UniversalRouterContainer = createContainer<
   displayName: 'UniversalRouterContainer',
   onInit: () => ({ dispatch }, props) => {
     dispatch(actions.bootstrapStoreUniversal(props));
-    !isNodeEnvironment() && dispatch(actions.requestRouteResources());
+    !isServerEnvironment() && dispatch(actions.requestRouteResources());
   },
   onCleanup: () => () => {
     if (process.env.NODE_ENV === 'development') {

--- a/src/controllers/router-store/index.tsx
+++ b/src/controllers/router-store/index.tsx
@@ -14,11 +14,16 @@ import {
   DEFAULT_MATCH,
   DEFAULT_ROUTE,
 } from '../../common/constants';
-import { getRouteContext } from '../../common/utils/get-route-context';
+import { getRouteContext, isNodeEnvironment } from '../../common/utils';
 import { getResourceStore } from '../resource-store';
 import { getResourcesForNextLocation } from '../resource-store/utils';
 
-import { AllRouterActions, ContainerProps, EntireRouterState } from './types';
+import {
+  AllRouterActions,
+  ContainerProps,
+  UniversalRouterContainerProps,
+  EntireRouterState,
+} from './types';
 import { getRelativePath, isExternalAbsolutePath } from './utils';
 
 export const INITIAL_STATE: EntireRouterState = {
@@ -53,6 +58,28 @@ const actions: AllRouterActions = {
     getResourceStore().actions.hydrate({ resourceContext, resourceData });
 
     if (!isStatic) {
+      dispatch(actions.listen());
+    }
+  },
+
+  /**
+   * Duplicate method that uses isNodeEnvironment instead of removed isStatic prop
+   * internally. We can remove this when UniversalRouter replaces Router completely.
+   */
+  bootstrapStoreUniversal: props => ({ setState, dispatch }) => {
+    const { resourceContext, resourceData, ...initialProps } = props;
+    const { history, routes } = initialProps;
+    const routeContext = getRouteContext(history.location, routes);
+
+    setState({
+      ...initialProps,
+      ...routeContext,
+      route: routeContext.route,
+      match: routeContext.match,
+    });
+    getResourceStore().actions.hydrate({ resourceContext, resourceData });
+
+    if (!isNodeEnvironment()) {
       dispatch(actions.listen());
     }
   },
@@ -197,12 +224,32 @@ export const RouterContainer = createContainer<State, Actions, ContainerProps>(
       if (process.env.NODE_ENV === 'development') {
         // eslint-disable-next-line no-console
         console.warn(
-          `Warning: @atlaskit/router has been unmounted! Was this intentional? Resources will be refetched when the router is mounted again.`
+          `Warning: react-resource-router has been unmounted! Was this intentional? Resources will be refetched when the router is mounted again.`
         );
       }
     },
   }
 );
+
+export const UniversalRouterContainer = createContainer<
+  State,
+  Actions,
+  UniversalRouterContainerProps
+>(RouterStore, {
+  displayName: 'UniversalRouterContainer',
+  onInit: () => ({ dispatch }, props) => {
+    dispatch(actions.bootstrapStoreUniversal(props));
+    !isNodeEnvironment() && dispatch(actions.requestRouteResources());
+  },
+  onCleanup: () => () => {
+    if (process.env.NODE_ENV === 'development') {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `Warning: react-resource-router has been unmounted! Was this intentional? Resources will be refetched when the router is mounted again.`
+      );
+    }
+  },
+});
 
 export const RouterSubscriber = createSubscriber<State, Actions>(RouterStore, {
   displayName: 'BaseRouterSubscriber',

--- a/src/controllers/router-store/types.ts
+++ b/src/controllers/router-store/types.ts
@@ -46,10 +46,15 @@ export type ContainerProps = {
   resourceContext?: ResourceStoreContext;
 };
 
+export type UniversalRouterContainerProps = Omit<ContainerProps, 'isStatic'>;
+
 export type RouterAction = Action<EntireRouterState, AllRouterActions>;
 
 type PrivateRouterActions = {
   bootstrapStore: (initialState: ContainerProps) => RouterAction;
+  bootstrapStoreUniversal: (
+    initialState: UniversalRouterContainerProps
+  ) => RouterAction;
   requestRouteResources: () => RouterAction;
   listen: () => RouterAction;
 };

--- a/src/controllers/router-store/types.ts
+++ b/src/controllers/router-store/types.ts
@@ -15,6 +15,7 @@ import {
   Route,
   Routes,
 } from '../../common/types';
+import { MemoryHistory } from 'history';
 
 type PublicStateProperties = {
   location: Location;
@@ -38,7 +39,7 @@ export type EntireRouterState = PublicStateProperties & PrivateStateProperties;
 
 export type ContainerProps = {
   isStatic?: boolean;
-  history: BrowserHistory;
+  history: BrowserHistory | MemoryHistory;
   location?: Location;
   routes: Routes;
   resourceData?: ResourceStoreData;

--- a/src/controllers/router-store/types.ts
+++ b/src/controllers/router-store/types.ts
@@ -46,7 +46,10 @@ export type ContainerProps = {
   resourceContext?: ResourceStoreContext;
 };
 
-export type UniversalRouterContainerProps = Omit<ContainerProps, 'isStatic'>;
+export type UniversalRouterContainerProps = { isGlobal?: boolean } & Omit<
+  ContainerProps,
+  'isStatic'
+>;
 
 export type RouterAction = Action<EntireRouterState, AllRouterActions>;
 

--- a/src/controllers/universal-router/index.tsx
+++ b/src/controllers/universal-router/index.tsx
@@ -19,7 +19,7 @@ const getInferredHistory = (history: BrowserHistory, location?: string) =>
  */
 export class UniversalRouter extends Component<UniversalRouterProps> {
   static defaultProps = {
-    isStatic: false,
+    isGlobal: true,
     history: DEFAULT_HISTORY,
   };
 
@@ -82,6 +82,7 @@ export class UniversalRouter extends Component<UniversalRouterProps> {
       location,
       resourceContext,
       resourceData,
+      isGlobal,
     } = this.props;
 
     return (
@@ -90,7 +91,7 @@ export class UniversalRouter extends Component<UniversalRouterProps> {
         history={getInferredHistory(history, location)}
         resourceContext={resourceContext}
         resourceData={resourceData}
-        isGlobal
+        isGlobal={isGlobal}
       >
         {children}
       </UniversalRouterContainer>

--- a/src/controllers/universal-router/index.tsx
+++ b/src/controllers/universal-router/index.tsx
@@ -7,7 +7,7 @@ import { isServerEnvironment } from '../../common/utils';
 import { UniversalRouterProps, RequestResourcesParams } from './types';
 import { createMemoryHistory, createLocation } from 'history';
 import { BrowserHistory } from 'src/common/types';
-import { getResourceStore } from '../resource-store';
+import { getResourceStore, ResourceContainer } from '../resource-store';
 import { getRouterStore } from '../router-store';
 
 const getInferredHistory = (history: BrowserHistory, location?: string) =>
@@ -93,7 +93,7 @@ export class UniversalRouter extends Component<UniversalRouterProps> {
         resourceData={resourceData}
         isGlobal={isGlobal}
       >
-        {children}
+        <ResourceContainer isGlobal={isGlobal}>{children}</ResourceContainer>
       </UniversalRouterContainer>
     );
   }

--- a/src/controllers/universal-router/index.tsx
+++ b/src/controllers/universal-router/index.tsx
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import { DEFAULT_HISTORY } from '../../common/constants';
 import { getRouterState, UniversalRouterContainer } from '../router-store';
 import { UnlistenHistory } from '../router-store/types';
-import { isNodeEnvironment } from '../../common/utils';
+import { isServerEnvironment } from '../../common/utils';
 import { UniversalRouterProps, RequestResourcesParams } from './types';
 import { createMemoryHistory, createLocation } from 'history';
 import { BrowserHistory } from 'src/common/types';
@@ -58,7 +58,7 @@ export class UniversalRouter extends Component<UniversalRouterProps> {
   unlistenHistory: UnlistenHistory | null = null;
 
   componentDidMount() {
-    if (!isNodeEnvironment()) {
+    if (!isServerEnvironment()) {
       const state = getRouterState();
       this.unlistenHistory = state.unlisten;
     }

--- a/src/controllers/universal-router/index.tsx
+++ b/src/controllers/universal-router/index.tsx
@@ -1,0 +1,102 @@
+import React, { Component } from 'react';
+
+import { DEFAULT_HISTORY } from '../../common/constants';
+import { getRouterState, RouterContainer } from '../router-store';
+import { UnlistenHistory } from '../router-store/types';
+import { isNodeEnvironment } from '../../common/utils';
+import { UniversalRouterProps, RequestResourcesParams } from './types';
+import { createMemoryHistory, createLocation } from 'history';
+import { BrowserHistory } from 'src/common/types';
+import { getResourceStore } from '../resource-store';
+import { getRouterStore } from '../router-store';
+
+const getIsStaticRouter = (isStatic?: boolean) =>
+  isStatic === undefined ? isNodeEnvironment() : isStatic;
+
+const getInferredHistory = (history: BrowserHistory, location?: string) =>
+  location ? createMemoryHistory({ initialEntries: [location] }) : history;
+
+/**
+ * Default prop provider for the RouterContainer.
+ *
+ */
+export class UniversalRouter extends Component<UniversalRouterProps> {
+  static defaultProps = {
+    isStatic: false,
+    history: DEFAULT_HISTORY,
+  };
+
+  /**
+   * The entry point for requesting resource data on the server.
+   * Pass the result data into the router as a prop in order to hydrate it.
+   * TODO: return type
+   */
+  static async requestResources(props: RequestResourcesParams) {
+    const { bootstrapStore, requestRouteResources } = getRouterStore().actions;
+    const { location, ...bootstrapProps } = props;
+    const initialEntries = [location];
+    const overrides = {
+      history: createMemoryHistory({ initialEntries }),
+      location: createLocation(location),
+      isStatic: true,
+    };
+
+    bootstrapStore({ ...bootstrapProps, ...overrides });
+
+    await requestRouteResources();
+
+    return getResourceStore().actions.getSafeData();
+  }
+
+  /**
+   * Keep a copy of the history listener so that we can be sure that
+   * on unmount we call the listener that was in the router store at the
+   * time of mounting.
+   *
+   * This prevents an issue where the wrong listener is removed if the router
+   * is re-mounted.
+   */
+  unlistenHistory: UnlistenHistory | null = null;
+
+  componentDidMount() {
+    if (!getIsStaticRouter(this.props.isStatic)) {
+      const state = getRouterState();
+      this.unlistenHistory = state.unlisten;
+    }
+  }
+
+  /**
+   * Ensures that the router store stops listening to history when the Router
+   * is unmounted.
+   */
+  componentWillUnmount() {
+    if (this.unlistenHistory) {
+      this.unlistenHistory();
+    }
+  }
+
+  render() {
+    const {
+      children,
+      routes,
+      history = DEFAULT_HISTORY,
+      isStatic,
+      location,
+      resourceContext,
+      resourceData,
+    } = this.props;
+
+    return (
+      <RouterContainer
+        routes={routes}
+        history={getInferredHistory(history, location)}
+        isStatic={getIsStaticRouter(isStatic)}
+        resourceContext={resourceContext}
+        resourceData={resourceData}
+        isGlobal
+      >
+        {children}
+      </RouterContainer>
+    );
+  }
+}

--- a/src/controllers/universal-router/types.ts
+++ b/src/controllers/universal-router/types.ts
@@ -1,0 +1,24 @@
+import { ReactNode } from 'react';
+
+import {
+  BrowserHistory,
+  ResourceStoreContext,
+  ResourceStoreData,
+  Routes,
+} from '../../common/types';
+
+export type UniversalRouterProps = {
+  history?: BrowserHistory;
+  isStatic?: boolean;
+  location?: string;
+  resourceContext?: ResourceStoreContext;
+  resourceData?: ResourceStoreData;
+  routes: Routes;
+  children: ReactNode;
+};
+
+export type RequestResourcesParams = {
+  location: string;
+  routes: Routes;
+  resourceContext?: ResourceStoreContext;
+};

--- a/src/controllers/universal-router/types.ts
+++ b/src/controllers/universal-router/types.ts
@@ -9,7 +9,7 @@ import {
 
 export type UniversalRouterProps = {
   history?: BrowserHistory;
-  isStatic?: boolean;
+  isGlobal?: boolean;
   location?: string;
   resourceContext?: ResourceStoreContext;
   resourceData?: ResourceStoreData;

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -6,6 +6,7 @@ import type { ComponentType, Node, ElementConfig } from 'react';
 import type { Action, BoundActions } from 'react-sweet-state';
 import type {
   BrowserHistory,
+  MemoryHistory,
   LocationShape as HistoryLocationShape,
 } from 'history/createBrowserHistory';
 
@@ -123,6 +124,15 @@ type ContainerProps = {|
   resourceContext?: ResourceStoreContext,
 |};
 
+type UniversalRouterContainerProps = {|
+  isGlobal?: boolean,
+  history: BrowserHistory | MemoryHistory,
+  location?: Location,
+  routes: Routes,
+  resourceData?: ResourceStoreData,
+  resourceContext?: ResourceStoreContext,
+|};
+
 type PublicStateProperties = {|
   location: Location,
   query: Query,
@@ -176,6 +186,15 @@ export type RouterAction = Action<
 export type RouterProps = {
   isStatic?: boolean,
   history?: BrowserHistory,
+  resourceContext?: ResourceStoreContext,
+  resourceData?: ResourceStoreData,
+  routes: Routes,
+  children: Node,
+};
+
+export type UniversalRouterProps = {
+  isGlobal?: boolean,
+  history?: BrowserHistory | MemoryHistory,
   resourceContext?: ResourceStoreContext,
   resourceData?: ResourceStoreData,
   routes: Routes,


### PR DESCRIPTION
### Added 

* `UniversalRouter` component - this component should work universally in both the browser and the server. 
* Tests for this which include all unit tests from the three routers we currently have 

### Fixed 

* The need for weird app tree composition described here https://atlassian-labs.github.io/react-resource-router/#/router/ssr?id=tree-composition

### Note 

* If we merge this and are happy with it, we can eventually delete `Router`, `StaticRouter` and `MemoryRouter` and just have this code as the only router that needs to be used.