### PR TITLE
Remove default legacy history and fix history on render

### DIFF
--- a/src/__tests__/unit/controllers/universal-router/test.tsx
+++ b/src/__tests__/unit/controllers/universal-router/test.tsx
@@ -126,7 +126,7 @@ describe('UniversalRouter', () => {
         .mockImplementation(() => mockHistory);
     });
 
-    it('should not respond to history changes', () => {
+    it('should listen to memory history if no history provided', () => {
       mount(
         <Router routes={[]} isGlobal={false}>
           <RouterSubscriber>
@@ -135,7 +135,7 @@ describe('UniversalRouter', () => {
         </Router>
       );
 
-      expect(mockHistory.listen).not.toHaveBeenCalled();
+      expect(mockHistory.listen).toHaveBeenCalled();
     });
 
     describe('static requestResources', () => {

--- a/src/controllers/universal-router/index.tsx
+++ b/src/controllers/universal-router/index.tsx
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 
 import { getRouterState, UniversalRouterContainer } from '../router-store';
 import { UnlistenHistory } from '../router-store/types';
-import { isServerEnvironment } from '../../common/utils';
 import { UniversalRouterProps, RequestResourcesParams } from './types';
 import { createMemoryHistory, createLocation } from 'history';
 import { BrowserHistory } from 'src/common/types';
@@ -60,10 +59,8 @@ export class UniversalRouter extends Component<UniversalRouterProps> {
   }
 
   componentDidMount() {
-    if (!isServerEnvironment()) {
-      const state = getRouterState();
-      this.unlistenHistory = state.unlisten;
-    }
+    const state = getRouterState();
+    this.unlistenHistory = state.unlisten;
   }
 
   /**

--- a/src/controllers/universal-router/index.tsx
+++ b/src/controllers/universal-router/index.tsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 
-import { DEFAULT_HISTORY } from '../../common/constants';
 import { getRouterState, UniversalRouterContainer } from '../router-store';
 import { UnlistenHistory } from '../router-store/types';
 import { isServerEnvironment } from '../../common/utils';
@@ -10,9 +9,6 @@ import { BrowserHistory } from 'src/common/types';
 import { getResourceStore, ResourceContainer } from '../resource-store';
 import { getRouterStore } from '../router-store';
 
-const getInferredHistory = (history: BrowserHistory, location?: string) =>
-  location ? createMemoryHistory({ initialEntries: [location] }) : history;
-
 /**
  * Default prop provider for the RouterContainer.
  *
@@ -20,7 +16,6 @@ const getInferredHistory = (history: BrowserHistory, location?: string) =>
 export class UniversalRouter extends Component<UniversalRouterProps> {
   static defaultProps = {
     isGlobal: true,
-    history: DEFAULT_HISTORY,
   };
 
   /**
@@ -56,6 +51,13 @@ export class UniversalRouter extends Component<UniversalRouterProps> {
    * is re-mounted.
    */
   unlistenHistory: UnlistenHistory | null = null;
+  history: BrowserHistory;
+
+  constructor(props: UniversalRouterProps) {
+    super(props);
+    const initialEntries = props.location ? [props.location] : [];
+    this.history = props.history || createMemoryHistory({ initialEntries });
+  }
 
   componentDidMount() {
     if (!isServerEnvironment()) {
@@ -78,8 +80,6 @@ export class UniversalRouter extends Component<UniversalRouterProps> {
     const {
       children,
       routes,
-      history = DEFAULT_HISTORY,
-      location,
       resourceContext,
       resourceData,
       isGlobal,
@@ -88,7 +88,7 @@ export class UniversalRouter extends Component<UniversalRouterProps> {
     return (
       <UniversalRouterContainer
         routes={routes}
-        history={getInferredHistory(history, location)}
+        history={this.history}
         resourceContext={resourceContext}
         resourceData={resourceData}
         isGlobal={isGlobal}


### PR DESCRIPTION
- `UniversalRouter` should not consume default history anymore, as we want to deprecate such behaviour
- `UniversalRouter` was creating new history at every re-render