### PR TITLE
fix type exports for older TS versions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ export {
   getRouteContext,
 } from './common/utils';
 
-export type {
+export {
   Location,
   Route,
   Routes,
@@ -41,7 +41,7 @@ export type {
   BrowserHistory,
 } from './common/types';
 
-export type {
+export {
   RouterActionsType,
   RouterActionPush,
   RouterActionReplace,


### PR DESCRIPTION
This fixes an issue for consumers who are using older versions of TS that aren't compatible with `export type {...}` syntax

