### PR TITLE
FIX: CRA/AF TypeScript incompatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,6 +121,6 @@
   "peerDependencies": {
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
-    "typescript": "^3.8.0"
+    "typescript": "^3.7.2"
   }
 }

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -2,9 +2,9 @@
 
 import { ComponentType, ReactNode } from 'react';
 
-import { History, Location as LocationShape } from 'history';
+import { History, Location as HistoryLocationShape } from 'history';
 
-export { LocationShape };
+export type LocationShape = HistoryLocationShape;
 
 export type Href = string;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+export { createBrowserHistory, createMemoryHistory } from 'history';
+
 export {
   Router,
   MemoryRouter,
@@ -14,7 +16,9 @@ export {
   createResource,
   useRouterActions,
 } from './controllers';
+
 export { RouteComponent, Link, noopRouterDecorator } from './ui';
+
 export {
   matchRoute,
   generatePath,
@@ -23,7 +27,7 @@ export {
   findRouterContext,
 } from './common/utils';
 
-export type {
+export {
   Location,
   Route,
   Routes,
@@ -40,13 +44,12 @@ export type {
   NavigationStatics,
   LinkProps,
   BrowserHistory,
+  LocationShape,
 } from './common/types';
 
-export type {
+export {
   RouterActionsType,
   RouterActionPush,
   RouterActionReplace,
   RouterSubscriberProps,
 } from './controllers/router-store/types';
-
-export { createBrowserHistory, createMemoryHistory } from 'history';


### PR DESCRIPTION
Fixes incompat issues with TS versions < 3.9 —

- `export type` syntax was introduced in 3.8 and it prevented users with lower TS versions from consuming the package
- CRA builds crash because of undefined type imports