### PR TITLE
Add new hooks - useQueryParam and usePathParam

### DIFF
--- a/docs/api/hooks.md
+++ b/docs/api/hooks.md
@@ -61,3 +61,30 @@ export const RouterActionsHookExample = () => {
   return <MyComponent push={push} />;
 };
 ```
+
+## useQueryParam
+
+You can use the `useQueryParam` hook to access the query params in current route.
+
+```js
+import { useQueryParam } from 'react-resource-router';
+
+// Current route in address bar — /home/projects?foo=bar
+
+export const MyComponent = () => {
+  const [foo, setFoo] = useQueryParam('foo');
+  // => foo will have the value 'bar'
+
+  const clickHandler = () => {
+    setFoo('baz');
+    // => Will update current route to /home/projects?foo=baz
+  };
+
+  return (
+    <div>
+      <p>Hello World!</p>
+      <button onClick={clickHandler}>Update param</button>
+    </div>
+  );
+};
+```

--- a/docs/api/hooks.md
+++ b/docs/api/hooks.md
@@ -64,7 +64,7 @@ export const RouterActionsHookExample = () => {
 
 ## useQueryParam
 
-You can use the `useQueryParam` hook to access the query params in current route.
+You can use the `useQueryParam` hook to access the query params in current route. Pass in `undefined` to remove a query param from the url.
 
 ```js
 import { useQueryParam } from 'react-resource-router';
@@ -78,6 +78,35 @@ export const MyComponent = () => {
   const clickHandler = () => {
     setFoo('baz');
     // => Will update current route to /home/projects?foo=baz
+  };
+
+  return (
+    <div>
+      <p>Hello World!</p>
+      <button onClick={clickHandler}>Update param</button>
+    </div>
+  );
+};
+```
+
+## usePathParam
+
+You can use the `usePathParam` hook to access the path params in current route. Pass in `undefined` to remove an [optional param](https://github.com/pillarjs/path-to-regexp#optional) from the url.
+
+```js
+import { usePathParam } from 'react-resource-router';
+
+// path — /projects/:projectId/board/:boardId
+
+// Current route in address bar — /projects/123/board/456?foo=bar
+
+export const MyComponent = () => {
+  const [projectId, setProjectId] = usePathParam('projectId');
+  // => projectId will have the value '123'
+
+  const clickHandler = () => {
+    setProjectId('222');
+    // => Will update current route to /projects/222/board/456?foo=bar
   };
 
   return (

--- a/examples/basic-routing/index.html
+++ b/examples/basic-routing/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Example</title>
+    <title>Example - Basic Routing</title>
   </head>
 
   <body>

--- a/examples/hooks/home.tsx
+++ b/examples/hooks/home.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Link } from 'react-resource-router';
+
+const baseURL = '/hooks';
+
+const Home = () => {
+  return (
+    <div>
+      <h1>Available Hooks</h1>
+      <Link to={`${baseURL}/query-param?foo=abc&bar=xyz`}>useQueryParam</Link>
+    </div>
+  );
+};
+
+export default Home;

--- a/examples/hooks/home.tsx
+++ b/examples/hooks/home.tsx
@@ -7,7 +7,13 @@ const Home = () => {
   return (
     <div>
       <h1>Available Hooks</h1>
-      <Link to={`${baseURL}/query-param?foo=abc&bar=xyz`}>useQueryParam</Link>
+      <Link to={`${baseURL}/query-param?foo=abc&bar=xyz#abc`}>
+        useQueryParam
+      </Link>
+      <br />
+      <Link to={`${baseURL}/path-param/hello/world#abc?foo=abc&bar=xyz`}>
+        usePathParam
+      </Link>
     </div>
   );
 };

--- a/examples/hooks/index.html
+++ b/examples/hooks/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Example - Basic Routing with Resources</title>
+    <title>Example - Hooks</title>
   </head>
 
   <body>

--- a/examples/hooks/index.tsx
+++ b/examples/hooks/index.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import {
+  Router,
+  RouteComponent,
+  createBrowserHistory,
+} from 'react-resource-router';
+
+import Home from './home';
+import QueryParamExample from './use-query-param';
+
+const myHistory = createBrowserHistory();
+
+const baseURL = '/hooks';
+
+const appRoutes = [
+  {
+    name: 'home',
+    path: `${baseURL}`,
+    exact: true,
+    component: Home,
+    navigation: null,
+  },
+  {
+    name: 'query-param',
+    path: `${baseURL}/query-param`,
+    exact: true,
+    component: QueryParamExample,
+    navigation: null,
+  },
+];
+
+const App = () => {
+  return (
+    <Router routes={appRoutes} history={myHistory}>
+      <RouteComponent />
+    </Router>
+  );
+};
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/examples/hooks/index.tsx
+++ b/examples/hooks/index.tsx
@@ -9,6 +9,7 @@ import {
 
 import Home from './home';
 import QueryParamExample from './use-query-param';
+import PathParamExample from './use-path-param';
 
 const myHistory = createBrowserHistory();
 
@@ -27,6 +28,13 @@ const appRoutes = [
     path: `${baseURL}/query-param`,
     exact: true,
     component: QueryParamExample,
+    navigation: null,
+  },
+  {
+    name: 'path-param',
+    path: `${baseURL}/path-param/:foo/:bar`,
+    exact: true,
+    component: PathParamExample,
     navigation: null,
   },
 ];

--- a/examples/hooks/use-path-param.tsx
+++ b/examples/hooks/use-path-param.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link, useQueryParam } from 'react-resource-router';
+import { Link, usePathParam } from 'react-resource-router';
 
 const baseURL = '/hooks';
 
@@ -26,7 +26,7 @@ const generateLightColorHex = () => {
 
 const UpdateButton = ({ for: paramKey = '' }) => {
   //eslint-disable-next-line
-  const [param, setParam] = useQueryParam(paramKey);
+  const [param, setParam] = usePathParam(paramKey);
 
   return (
     <div
@@ -35,14 +35,13 @@ const UpdateButton = ({ for: paramKey = '' }) => {
       }}
     >
       <button onClick={() => setParam(randomStr(5))}>Update {paramKey}</button>
-      <button onClick={() => setParam(undefined)}>Empty {paramKey}</button>
     </div>
   );
 };
 
 const ComponentFoo = () => {
   // eslint-disable-next-line
-  const [foo, setFoo] = useQueryParam('foo');
+  const [foo, setFoo] = usePathParam('foo');
 
   return (
     <div
@@ -63,7 +62,7 @@ const ComponentFoo = () => {
 
 const ComponentBar = () => {
   // eslint-disable-next-line
-  const [bar, setBar] = useQueryParam('bar');
+  const [bar, setBar] = usePathParam('bar');
 
   return (
     <div
@@ -82,10 +81,10 @@ const ComponentBar = () => {
   );
 };
 
-const QueryParamExample = () => {
+const PathParamExample = () => {
   return (
     <div>
-      <h1>useQueryParam</h1>
+      <h1>usePathParam - /hooks/use-path-param/:foo/:bar</h1>
       <ComponentFoo />
       <UpdateButton for={'foo'} />
       <ComponentBar />
@@ -95,4 +94,4 @@ const QueryParamExample = () => {
   );
 };
 
-export default QueryParamExample;
+export default PathParamExample;

--- a/examples/hooks/use-query-param.tsx
+++ b/examples/hooks/use-query-param.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { Link, useQueryParam } from 'react-resource-router';
+
+const baseURL = '/hooks';
+
+const randomStr = (length: number) => {
+  let result = '';
+  const characters = 'abcdefghijklmnopqrstuvwxyz';
+  const charactersLength = characters.length;
+  for (let i = 0; i < length; i++) {
+    result += characters.charAt(Math.floor(Math.random() * charactersLength));
+  }
+
+  return result;
+};
+
+const generateLightColorHex = () => {
+  let color = '#';
+  for (let i = 0; i < 3; i++)
+    color += (
+      '0' + Math.floor(((1 + Math.random()) * Math.pow(16, 2)) / 2).toString(16)
+    ).slice(-2);
+
+  return color;
+};
+
+const UpdateButton = ({ for: paramKey = '' }) => {
+  //eslint-disable-next-line
+  const [param, setParam] = useQueryParam(paramKey);
+
+  return (
+    <div
+      style={{
+        margin: '20px 0',
+      }}
+    >
+      <button onClick={() => setParam(randomStr(5))}>Update {paramKey}</button>
+    </div>
+  );
+};
+
+const ComponentFoo = () => {
+  // eslint-disable-next-line
+  const [foo, setFoo] = useQueryParam('foo');
+
+  return (
+    <div
+      style={{
+        margin: '20px 0',
+        padding: '20px',
+        backgroundColor: generateLightColorHex(),
+      }}
+    >
+      <div>
+        I am ComponentFoo that consumes 'foo' query param. My background color
+        changes on every render.
+      </div>
+      <p>foo={foo}</p>
+    </div>
+  );
+};
+
+const ComponentBar = () => {
+  // eslint-disable-next-line
+  const [bar, setBar] = useQueryParam('bar');
+
+  return (
+    <div
+      style={{
+        margin: '20px 0',
+        padding: '20px',
+        backgroundColor: generateLightColorHex(),
+      }}
+    >
+      <div>
+        I am ComponentBar that consumes 'bar' query param. My background color
+        changes on every render.
+      </div>
+      <p>bar={bar}</p>
+    </div>
+  );
+};
+
+const QueryParamExample = () => {
+  return (
+    <div>
+      <h1>useQueryParam</h1>
+      <ComponentFoo />
+      <UpdateButton for={'foo'} />
+      <ComponentBar />
+      <UpdateButton for={'bar'} />
+      <Link to={`${baseURL}`}>Go back to list of hooks</Link>
+    </div>
+  );
+};
+
+export default QueryParamExample;

--- a/src/__tests__/unit/controllers/hooks/router-store/test.tsx
+++ b/src/__tests__/unit/controllers/hooks/router-store/test.tsx
@@ -1,0 +1,164 @@
+import React from 'react';
+
+import { mount } from 'enzyme';
+import * as historyHelper from 'history';
+import { defaultRegistry } from 'react-sweet-state';
+import { act } from 'react-dom/test-utils';
+
+import { MemoryRouter } from '../../../../../controllers/memory-router';
+import { useQueryParam } from '../../../../../controllers/hooks/router-store';
+
+const mockLocation = {
+  pathname: '/pathname',
+  search: '?foo=bar&hello=world',
+  hash: '#hash',
+};
+
+const mockHistory = {
+  push: jest.fn(),
+  replace: jest.fn(),
+  goBack: jest.fn(),
+  goForward: jest.fn(),
+  registerBlock: jest.fn(),
+  listen: jest.fn(),
+  createHref: jest.fn(),
+  location: mockLocation,
+  block: jest.fn(),
+};
+
+const mockRoutes = [
+  {
+    path: '/pathname',
+    component: () => <div>path</div>,
+    name: '',
+  },
+  {
+    path: '/blah',
+    component: () => <div>path</div>,
+    name: '',
+  },
+];
+
+const nextTick = () => new Promise(resolve => setTimeout(resolve));
+
+const MockComponent = ({ children, ...rest }: any) => {
+  return children(rest);
+};
+
+describe('useQueryParam', () => {
+  const { location } = window;
+
+  beforeAll(() => {
+    delete window.location;
+    // @ts-ignore
+    window.location = {};
+    Object.defineProperties(window.location, {
+      href: { value: location.href },
+      assign: { value: jest.fn() },
+      replace: { value: jest.fn() },
+    });
+  });
+
+  beforeEach(() => {
+    jest
+      .spyOn(historyHelper, 'createMemoryHistory')
+      // @ts-ignore
+      .mockImplementation(() => mockHistory);
+  });
+
+  afterEach(() => {
+    defaultRegistry.stores.clear();
+    jest.resetAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    window.location = location;
+  });
+
+  it('should return the right param value', () => {
+    mount(
+      <MemoryRouter routes={mockRoutes}>
+        <MockComponent>
+          {() => {
+            const [param] = useQueryParam('foo');
+            expect(param).toEqual('bar');
+
+            return <div>I am a subscriber</div>;
+          }}
+        </MockComponent>
+      </MemoryRouter>
+    );
+  });
+
+  it('should return undefined for non-existent params', () => {
+    mount(
+      <MemoryRouter routes={mockRoutes}>
+        <MockComponent>
+          {() => {
+            const [param] = useQueryParam('iamnotaqueryparam');
+            expect(param).toEqual(undefined);
+
+            return <div>I am a subscriber</div>;
+          }}
+        </MockComponent>
+      </MemoryRouter>
+    );
+  });
+
+  it('should update URL with new param value', async () => {
+    const mockPath = mockLocation.pathname;
+    let qpVal: string | undefined, qpUpdateFn: (qp: string) => void;
+
+    mount(
+      <MemoryRouter routes={mockRoutes}>
+        <MockComponent>
+          {() => {
+            const [param, setParam] = useQueryParam('foo');
+            qpVal = param;
+            qpUpdateFn = setParam;
+
+            return <div>I am a subscriber</div>;
+          }}
+        </MockComponent>
+      </MemoryRouter>
+    );
+
+    expect(qpVal).toEqual('bar');
+
+    act(() => qpUpdateFn('newVal'));
+
+    await nextTick();
+
+    expect(mockHistory.push).toBeCalledWith(
+      `${mockPath}?hello=world&foo=newVal`
+    );
+  });
+
+  it('should remove param from URL when set to null', async () => {
+    const mockPath = mockLocation.pathname;
+    let qpVal: string | undefined, qpUpdateFn: (qp: string | null) => void;
+
+    mount(
+      <MemoryRouter routes={mockRoutes}>
+        <MockComponent>
+          {() => {
+            const [param, setParam] = useQueryParam('foo');
+            qpVal = param;
+            qpUpdateFn = setParam;
+
+            return <div>I am a subscriber</div>;
+          }}
+        </MockComponent>
+      </MemoryRouter>
+    );
+
+    expect(qpVal).toEqual('bar');
+
+    act(() => qpUpdateFn(null));
+
+    await nextTick();
+
+    expect(mockHistory.push).toBeCalledWith(`${mockPath}?hello=world`);
+  });
+});

--- a/src/__tests__/unit/controllers/hooks/router-store/test.tsx
+++ b/src/__tests__/unit/controllers/hooks/router-store/test.tsx
@@ -5,30 +5,22 @@ import * as historyHelper from 'history';
 import { defaultRegistry } from 'react-sweet-state';
 import { act } from 'react-dom/test-utils';
 
-import { MemoryRouter } from '../../../../../controllers/memory-router';
-import { useQueryParam } from '../../../../../controllers/hooks/router-store';
+import { Router } from '../../../../../controllers';
+import {
+  useQueryParam,
+  usePathParam,
+} from '../../../../../controllers/hooks/router-store';
+import { getRouterStore } from '../../../../../controllers/router-store';
 
 const mockLocation = {
-  pathname: '/pathname',
-  search: '?foo=bar&hello=world',
+  pathname: '/projects/123/board/456',
+  search: '?foo=hello&bar=world',
   hash: '#hash',
-};
-
-const mockHistory = {
-  push: jest.fn(),
-  replace: jest.fn(),
-  goBack: jest.fn(),
-  goForward: jest.fn(),
-  registerBlock: jest.fn(),
-  listen: jest.fn(),
-  createHref: jest.fn(),
-  location: mockLocation,
-  block: jest.fn(),
 };
 
 const mockRoutes = [
   {
-    path: '/pathname',
+    path: '/projects/:projectId/board/:boardId',
     component: () => <div>path</div>,
     name: '',
   },
@@ -39,6 +31,14 @@ const mockRoutes = [
   },
 ];
 
+const historyBuildOptions = {
+  initialEntries: [
+    `${mockLocation.pathname}${mockLocation.search}${mockLocation.hash}`,
+  ],
+};
+
+let history = historyHelper.createMemoryHistory(historyBuildOptions);
+let historyPushSpy = jest.spyOn(history, 'push');
 const nextTick = () => new Promise(resolve => setTimeout(resolve));
 
 const MockComponent = ({ children, ...rest }: any) => {
@@ -46,24 +46,9 @@ const MockComponent = ({ children, ...rest }: any) => {
 };
 
 describe('useQueryParam', () => {
-  const { location } = window;
-
-  beforeAll(() => {
-    delete window.location;
-    // @ts-ignore
-    window.location = {};
-    Object.defineProperties(window.location, {
-      href: { value: location.href },
-      assign: { value: jest.fn() },
-      replace: { value: jest.fn() },
-    });
-  });
-
   beforeEach(() => {
-    jest
-      .spyOn(historyHelper, 'createMemoryHistory')
-      // @ts-ignore
-      .mockImplementation(() => mockHistory);
+    history = historyHelper.createMemoryHistory(historyBuildOptions);
+    historyPushSpy = jest.spyOn(history, 'push');
   });
 
   afterEach(() => {
@@ -72,93 +57,359 @@ describe('useQueryParam', () => {
     jest.restoreAllMocks();
   });
 
-  afterAll(() => {
-    window.location = location;
-  });
-
   it('should return the right param value', () => {
     mount(
-      <MemoryRouter routes={mockRoutes}>
+      <Router routes={mockRoutes} history={history}>
         <MockComponent>
           {() => {
             const [param] = useQueryParam('foo');
-            expect(param).toEqual('bar');
+            expect(param).toEqual('hello');
 
-            return <div>I am a subscriber</div>;
+            return null;
           }}
         </MockComponent>
-      </MemoryRouter>
+      </Router>
     );
   });
 
   it('should return undefined for non-existent params', () => {
     mount(
-      <MemoryRouter routes={mockRoutes}>
+      <Router routes={mockRoutes} history={history}>
         <MockComponent>
           {() => {
             const [param] = useQueryParam('iamnotaqueryparam');
             expect(param).toEqual(undefined);
 
-            return <div>I am a subscriber</div>;
+            return null;
           }}
         </MockComponent>
-      </MemoryRouter>
+      </Router>
+    );
+  });
+
+  it('should return undefined for non-existent params and update the URL when set for the first time', async () => {
+    const mockPath = mockLocation.pathname;
+    let qpVal: string | undefined;
+    let qpUpdateFn: (qp: string) => void;
+
+    mount(
+      <Router routes={mockRoutes} history={history}>
+        <MockComponent>
+          {() => {
+            const [param, setParam] = useQueryParam('newqueryparam');
+            qpVal = param;
+            qpUpdateFn = setParam;
+
+            return null;
+          }}
+        </MockComponent>
+      </Router>
+    );
+    expect(qpVal).toEqual(undefined);
+    act(() => qpUpdateFn('val'));
+    await nextTick();
+
+    expect(historyPushSpy).toBeCalledWith(
+      `${mockPath}?foo=hello&bar=world&newqueryparam=val#hash`
     );
   });
 
   it('should update URL with new param value', async () => {
     const mockPath = mockLocation.pathname;
-    let qpVal: string | undefined, qpUpdateFn: (qp: string) => void;
+    let qpVal: string | undefined;
+    let qpUpdateFn: (qp: string) => void;
 
     mount(
-      <MemoryRouter routes={mockRoutes}>
+      <Router routes={mockRoutes} history={history}>
         <MockComponent>
           {() => {
             const [param, setParam] = useQueryParam('foo');
             qpVal = param;
             qpUpdateFn = setParam;
 
-            return <div>I am a subscriber</div>;
+            return null;
           }}
         </MockComponent>
-      </MemoryRouter>
+      </Router>
     );
 
-    expect(qpVal).toEqual('bar');
-
+    expect(qpVal).toEqual('hello');
     act(() => qpUpdateFn('newVal'));
-
     await nextTick();
 
-    expect(mockHistory.push).toBeCalledWith(
-      `${mockPath}?hello=world&foo=newVal`
+    expect(historyPushSpy).toBeCalledWith(
+      `${mockPath}?foo=newVal&bar=world#hash`
     );
   });
 
-  it('should remove param from URL when set to null', async () => {
+  it('should remove param from URL when set to undefined', async () => {
     const mockPath = mockLocation.pathname;
-    let qpVal: string | undefined, qpUpdateFn: (qp: string | null) => void;
+    let qpVal: string | undefined;
+    let qpUpdateFn: (qp: string | undefined) => void;
 
     mount(
-      <MemoryRouter routes={mockRoutes}>
+      <Router routes={mockRoutes} history={history}>
         <MockComponent>
           {() => {
             const [param, setParam] = useQueryParam('foo');
             qpVal = param;
             qpUpdateFn = setParam;
 
-            return <div>I am a subscriber</div>;
+            return null;
           }}
         </MockComponent>
-      </MemoryRouter>
+      </Router>
     );
 
-    expect(qpVal).toEqual('bar');
+    expect(qpVal).toEqual('hello');
 
-    act(() => qpUpdateFn(null));
+    act(() => qpUpdateFn(undefined));
 
     await nextTick();
 
-    expect(mockHistory.push).toBeCalledWith(`${mockPath}?hello=world`);
+    expect(qpVal).toEqual(undefined);
+    expect(historyPushSpy).toBeCalledWith(`${mockPath}?bar=world#hash`);
+  });
+
+  it('should only re-render components hooked to a specific param', async () => {
+    let fooVal: string | undefined;
+    let barVal: string | undefined;
+    let fooUpdateFn: (qp: string) => void;
+    let barUpdateFn: (qp: string) => void;
+
+    let renderedFoo = 0;
+    const ComponentFoo = () => {
+      const [foo, setFoo] = useQueryParam('foo');
+      fooVal = foo;
+      fooUpdateFn = setFoo;
+      renderedFoo++;
+
+      return null;
+    };
+    let renderedBar = 0;
+    const ComponentBar = () => {
+      const [bar, setBar] = useQueryParam('bar');
+      barVal = bar;
+      barUpdateFn = setBar;
+      renderedBar++;
+
+      return null;
+    };
+
+    mount(
+      <Router
+        routes={mockRoutes}
+        history={historyHelper.createBrowserHistory()}
+      >
+        <ComponentFoo />
+        <ComponentBar />
+      </Router>
+    );
+    expect(renderedFoo).toEqual(1);
+    expect(renderedBar).toEqual(1);
+
+    const { storeState, actions } = getRouterStore();
+
+    actions.push('/projects/123/board/456?foo=hello&bar=world');
+    await nextTick();
+
+    expect(fooVal).toEqual('hello');
+    expect(barVal).toEqual('world');
+    expect(renderedFoo).toEqual(2);
+    expect(renderedBar).toEqual(2);
+
+    act(() => fooUpdateFn('newVal'));
+    await nextTick();
+
+    // URL is now — /projects/123/board/456?foo=newVal&bar=world
+    expect(storeState.getState().location.pathname).toEqual(
+      '/projects/123/board/456'
+    );
+    expect(storeState.getState().location.search).toEqual(
+      '?foo=newVal&bar=world'
+    );
+    expect(fooVal).toEqual('newVal');
+    expect(barVal).toEqual('world');
+    expect(renderedFoo).toEqual(3);
+    expect(renderedBar).toEqual(2);
+
+    act(() => barUpdateFn('newVal'));
+    await nextTick();
+
+    // URL is now — /projects/123/board/456?foo=newVal&bar=newVal
+    expect(storeState.getState().location.pathname).toEqual(
+      '/projects/123/board/456'
+    );
+    expect(storeState.getState().location.search).toEqual(
+      '?foo=newVal&bar=newVal'
+    );
+    expect(fooVal).toEqual('newVal');
+    expect(barVal).toEqual('newVal');
+    expect(renderedFoo).toEqual(3);
+    expect(renderedBar).toEqual(3);
+  });
+});
+
+describe('usePathParam', () => {
+  beforeEach(() => {
+    history = historyHelper.createMemoryHistory(historyBuildOptions);
+    historyPushSpy = jest.spyOn(history, 'push');
+  });
+
+  afterEach(() => {
+    defaultRegistry.stores.clear();
+    jest.resetAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  it('should return the right param value', () => {
+    let ppVal: string | undefined;
+
+    mount(
+      <Router routes={mockRoutes} history={history}>
+        <MockComponent>
+          {() => {
+            const [param] = usePathParam('projectId');
+            ppVal = param;
+
+            return null;
+          }}
+        </MockComponent>
+      </Router>
+    );
+    expect(ppVal).toEqual('123');
+  });
+
+  it('should return undefined for non-existent params', () => {
+    let ppVal: string | undefined;
+    mount(
+      <Router routes={mockRoutes} history={history}>
+        <MockComponent>
+          {() => {
+            const [param] = usePathParam('iamnotapathparam');
+            ppVal = param;
+
+            return null;
+          }}
+        </MockComponent>
+      </Router>
+    );
+    expect(ppVal).toEqual(undefined);
+  });
+
+  it('should update URL with new param value', async () => {
+    let ppVal: string | undefined;
+    let ppUpdateFn: (qp: string | undefined) => void;
+
+    mount(
+      <Router routes={mockRoutes} history={history}>
+        <MockComponent>
+          {() => {
+            const [param, setParam] = usePathParam('projectId');
+            ppVal = param;
+            ppUpdateFn = setParam;
+
+            return null;
+          }}
+        </MockComponent>
+      </Router>
+    );
+
+    expect(ppVal).toEqual('123');
+
+    act(() => ppUpdateFn('newVal'));
+    await nextTick();
+
+    const { storeState } = getRouterStore();
+    const expectedPath = `/projects/newVal/board/456${mockLocation.search}${mockLocation.hash}`;
+    expect(historyPushSpy).toBeCalledWith(expectedPath);
+    expect(storeState.getState().location.pathname).toEqual(
+      '/projects/newVal/board/456'
+    );
+  });
+
+  it('should remove :optional? param from URL when updated with undefined', async () => {
+    let ppVal: string | undefined;
+    let ppUpdateFn: (qp: string | undefined) => void;
+
+    const mockRouteWithOptionalParam = {
+      path: '/projects/:projectId/board/:boardId/:issueId?',
+      component: () => <div>path</div>,
+      name: '',
+    };
+    mount(
+      <Router routes={[mockRouteWithOptionalParam]} history={history}>
+        <MockComponent>
+          {() => {
+            const [param, setParam] = usePathParam('issueId');
+            ppVal = param;
+            ppUpdateFn = setParam;
+
+            return null;
+          }}
+        </MockComponent>
+      </Router>
+    );
+
+    expect(ppVal).toEqual(undefined);
+
+    act(() => ppUpdateFn('newVal'));
+    await nextTick();
+
+    expect(ppVal).toEqual('newVal');
+    const { storeState } = getRouterStore();
+    let expectedPath = `/projects/123/board/456/newVal${mockLocation.search}${mockLocation.hash}`;
+    expect(historyPushSpy).toBeCalledWith(expectedPath);
+    expect(storeState.getState().location.pathname).toEqual(
+      '/projects/123/board/456/newVal'
+    );
+
+    act(() => ppUpdateFn(undefined));
+    await nextTick();
+
+    expect(ppVal).toEqual(undefined);
+    expectedPath = `/projects/123/board/456${mockLocation.search}${mockLocation.hash}`;
+    expect(historyPushSpy).toBeCalledWith(expectedPath);
+    expect(storeState.getState().location.pathname).toEqual(
+      '/projects/123/board/456'
+    );
+  });
+
+  it('should throw when non-optional params are set undefined', async () => {
+    let ppVal: string | undefined;
+    let ppUpdateFn: (qp: string | undefined) => void;
+
+    const mockRouteWithOptionalParam = {
+      path: '/projects/:projectId/board/:boardId/:issueId?',
+      component: () => <div>path</div>,
+      name: '',
+    };
+    mount(
+      <Router routes={[mockRouteWithOptionalParam]} history={history}>
+        <MockComponent>
+          {() => {
+            const [param, setParam] = usePathParam('boardId');
+            ppVal = param;
+            ppUpdateFn = setParam;
+
+            return null;
+          }}
+        </MockComponent>
+      </Router>
+    );
+
+    expect(ppVal).toEqual('456');
+
+    act(() => ppUpdateFn('newVal'));
+    await nextTick();
+
+    expect(ppVal).toEqual('newVal');
+    const { storeState } = getRouterStore();
+    const expectedPath = `/projects/123/board/newVal${mockLocation.search}${mockLocation.hash}`;
+    expect(historyPushSpy).toBeCalledWith(expectedPath);
+    expect(storeState.getState().location.pathname).toEqual(
+      '/projects/123/board/newVal'
+    );
+    expect(() => ppUpdateFn(undefined)).toThrow();
   });
 });

--- a/src/__tests__/unit/controllers/hooks/router-store/test.tsx
+++ b/src/__tests__/unit/controllers/hooks/router-store/test.tsx
@@ -248,6 +248,52 @@ describe('useQueryParam', () => {
     expect(renderedFoo).toEqual(3);
     expect(renderedBar).toEqual(3);
   });
+
+  it('should return the right param value when two hooks are used in the same component', async () => {
+    const mockPath = mockLocation.pathname;
+    let fooVal: string | undefined;
+    let fooUpdateFn: (qp: string) => void;
+    let barVal: string | undefined;
+    let barUpdateFn: (qp: string) => void;
+
+    mount(
+      <Router routes={mockRoutes} history={history}>
+        <MockComponent>
+          {() => {
+            const [foo, setFoo] = useQueryParam('foo');
+            const [bar, setBar] = useQueryParam('bar');
+            fooVal = foo;
+            fooUpdateFn = setFoo;
+            barVal = bar;
+            barUpdateFn = setBar;
+
+            return null;
+          }}
+        </MockComponent>
+      </Router>
+    );
+
+    expect(fooVal).toEqual('hello');
+    expect(barVal).toEqual('world');
+
+    act(() => fooUpdateFn('newFoo'));
+    await nextTick();
+
+    expect(fooVal).toEqual('newFoo');
+    expect(barVal).toEqual('world');
+    expect(historyPushSpy).toBeCalledWith(
+      `${mockPath}?foo=newFoo&bar=world#hash`
+    );
+
+    act(() => barUpdateFn('newBar'));
+    await nextTick();
+
+    expect(fooVal).toEqual('newFoo');
+    expect(barVal).toEqual('newBar');
+    expect(historyPushSpy).toBeCalledWith(
+      `${mockPath}?foo=newFoo&bar=newBar#hash`
+    );
+  });
 });
 
 describe('usePathParam', () => {

--- a/src/__tests__/unit/controllers/router-store/utils/test.ts
+++ b/src/__tests__/unit/controllers/router-store/utils/test.ts
@@ -2,6 +2,7 @@ import {
   getRelativePath,
   isAbsolutePath,
   isExternalAbsolutePath,
+  updateQueryParams,
 } from '../../../../../controllers/router-store/utils/path-utils';
 
 describe('path utils', () => {
@@ -79,6 +80,68 @@ describe('path utils', () => {
       ];
 
       paths.forEach(path => expect(isExternalAbsolutePath(path)).toBeTruthy());
+    });
+  });
+
+  describe('updateQueryParams', () => {
+    it('should update query params in URL without hash', () => {
+      const location = {
+        pathname: '/browse',
+        search: '?foo=hello&bar=world',
+        hash: '',
+      };
+
+      const query = {
+        foo: 'newVal',
+      };
+
+      const expectedOutput = '/browse?foo=newVal';
+
+      expect(updateQueryParams(location, query)).toEqual(expectedOutput);
+    });
+
+    it('should update query params in URL with hash', () => {
+      const location = {
+        pathname: '/browse',
+        search: '?foo=hello&bar=world',
+        hash: '#abc',
+      };
+
+      const query = {
+        foo: 'newVal',
+      };
+
+      const expectedOutput = '/browse?foo=newVal#abc';
+
+      expect(updateQueryParams(location, query)).toEqual(expectedOutput);
+    });
+
+    it('should return proper URL when query obj is empty', () => {
+      const location = {
+        pathname: '/browse',
+        search: '?foo=hello&bar=world',
+        hash: '#abc',
+      };
+
+      const query = {};
+
+      const expectedOutput = '/browse#abc';
+
+      expect(updateQueryParams(location, query)).toEqual(expectedOutput);
+    });
+
+    it('should return proper URL', () => {
+      const location = {
+        pathname: '/browse',
+        search: '',
+        hash: '#abc',
+      };
+
+      const query = { foo: 'newVal' };
+
+      const expectedOutput = '/browse?foo=newVal#abc';
+
+      expect(updateQueryParams(location, query)).toEqual(expectedOutput);
     });
   });
 });

--- a/src/controllers/hooks/index.ts
+++ b/src/controllers/hooks/index.ts
@@ -1,2 +1,7 @@
 export { useResource } from './resource-store';
-export { useRouter, useRouterActions, useQueryParam } from './router-store';
+export {
+  useRouter,
+  useRouterActions,
+  useQueryParam,
+  usePathParam,
+} from './router-store';

--- a/src/controllers/hooks/index.ts
+++ b/src/controllers/hooks/index.ts
@@ -1,2 +1,2 @@
 export { useResource } from './resource-store';
-export { useRouter, useRouterActions } from './router-store';
+export { useRouter, useRouterActions, useQueryParam } from './router-store';

--- a/src/controllers/hooks/router-store/index.tsx
+++ b/src/controllers/hooks/router-store/index.tsx
@@ -1,5 +1,18 @@
-import { useRouterStore, useRouterStoreStatic } from '../../router-store';
-import { RouterActionsType, RouterState } from '../../router-store/types';
+import React from 'react';
+import { qs } from 'url-parse';
+import {
+  useRouterStore,
+  useRouterStoreStatic,
+  RouterStore,
+  getRouterState,
+} from '../../router-store';
+import {
+  RouterActionsType,
+  RouterState,
+  EntireRouterState,
+  AllRouterActions,
+} from '../../router-store/types';
+import { createHook } from 'react-sweet-state';
 
 /**
  * Utility hook for accessing the public router store
@@ -17,4 +30,44 @@ export const useRouterActions = (): RouterActionsType => {
   const [, allActions] = useRouterStoreStatic();
 
   return allActions;
+};
+
+const useParam = createHook<
+  EntireRouterState,
+  AllRouterActions,
+  string,
+  { paramKey: string }
+>(RouterStore, {
+  selector: ({ query }, { paramKey }): string => query[paramKey],
+});
+
+/**
+ * Utility hook for accessing URL query params
+ */
+export const useQueryParam = (
+  paramKey: string
+): [string | undefined, (qp: string | null) => void] => {
+  const [paramVal, routerActions] = useParam({ paramKey });
+
+  const setQueryParam = React.useCallback(
+    (newValue: string | undefined | null) => {
+      const {
+        location: { pathname },
+        query,
+      } = getRouterState();
+      const { [paramKey]: deletedKey, ...newQueryObj } = query;
+
+      if (newValue) {
+        newQueryObj[paramKey] = newValue;
+      }
+
+      const stringifiedQuery = qs.stringify(newQueryObj);
+      routerActions.push(
+        pathname + (stringifiedQuery !== '' ? `?${stringifiedQuery}` : '')
+      );
+    },
+    [paramKey, routerActions]
+  );
+
+  return [paramVal, setQueryParam];
 };

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -10,6 +10,7 @@ export {
   useRouter,
   useRouterActions,
   useQueryParam,
+  usePathParam,
 } from './hooks';
 export { useResourceStoreContext } from './resource-store';
 export { createResource } from './resource-utils';

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -5,7 +5,12 @@ export { StaticRouter } from './static-router';
 export { RouterActions } from './router-actions';
 export { Redirect } from './redirect';
 export { withRouter } from './with-router';
-export { useResource, useRouter, useRouterActions } from './hooks';
+export {
+  useResource,
+  useRouter,
+  useRouterActions,
+  useQueryParam,
+} from './hooks';
 export { useResourceStoreContext } from './resource-store';
 export { createResource } from './resource-utils';
 export { RouteResourceEnabledSubscriber } from './router-store';

--- a/src/controllers/router-store/types.ts
+++ b/src/controllers/router-store/types.ts
@@ -61,6 +61,12 @@ type PrivateRouterActions = {
   requestRouteResources: () => RouterAction;
   listen: () => RouterAction;
   getContext: () => RouterAction;
+  pushQueryParam: (params: {
+    [key: string]: string | undefined;
+  }) => RouterAction;
+  pushPathParam: (params: {
+    [key: string]: string | undefined;
+  }) => RouterAction;
 };
 
 type PublicRouterActions = {

--- a/src/controllers/router-store/utils/index.ts
+++ b/src/controllers/router-store/utils/index.ts
@@ -1,1 +1,6 @@
-export { isExternalAbsolutePath, getRelativePath } from './path-utils';
+export {
+  isExternalAbsolutePath,
+  getRelativePath,
+  updateQueryParams,
+  getRelativeURLFromLocation,
+} from './path-utils';

--- a/src/controllers/router-store/utils/path-utils.ts
+++ b/src/controllers/router-store/utils/path-utils.ts
@@ -1,6 +1,6 @@
-import URL from 'url-parse';
+import URL, { qs } from 'url-parse';
 
-import { Href, Location } from '../../../common/types';
+import { Href, Location, Query } from '../../../common/types';
 
 export const isAbsolutePath = (path: string): boolean => {
   const regex = new RegExp('^([a-z]+://|//)', 'i');
@@ -27,4 +27,15 @@ export const getRelativePath = (path: Href | Location): string | Location => {
   const url = new URL(path);
 
   return `${url.pathname}${url.query}${url.hash}`;
+};
+
+export const updateQueryParams = (location: Location, query: Query): string => {
+  // @ts-ignore stringify accepts two params but it's type doesn't say so
+  const stringifiedQuery = qs.stringify(query, true);
+
+  return `${location.pathname}${stringifiedQuery}${location.hash}`;
+};
+
+export const getRelativeURLFromLocation = (location: Location): string => {
+  return `${location.pathname}${location.search}${location.hash}`;
 };

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -92,6 +92,8 @@ declare export function useRouter(): [
 ];
 declare export function useRouterActions(): BoundActions<RouterActionsType>;
 declare export function useResourceStoreContext(): ResourceStoreContext;
+declare export function useQueryParam(paramKey: string): [string | void, (qp: string | void) => void];
+declare export function usePathParam(paramKey: string): [string | void, (pp: string | void) => void];
 
 // Utils
 type WithRouterProps = RouteContext & {|

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export {
   useResource,
   useRouter,
   useQueryParam,
+  usePathParam,
   useResourceStoreContext,
   createResource,
   useRouterActions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export {
   ResourceSubscriber,
   useResource,
   useRouter,
+  useQueryParam,
   useResourceStoreContext,
   createResource,
   useRouterActions,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,6 +32,9 @@ module.exports = {
   devServer: {
     contentBase: path.resolve(__dirname, 'examples'),
     publicPath: '/',
+    // historyApiFallback: {
+    //   rewrites: [{ from: /\/hooks\/*/, to: '/hooks/index.html' }],
+    // },
   },
 
   output: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,9 +32,6 @@ module.exports = {
   devServer: {
     contentBase: path.resolve(__dirname, 'examples'),
     publicPath: '/',
-    // historyApiFallback: {
-    //   rewrites: [{ from: /\/hooks\/*/, to: '/hooks/index.html' }],
-    // },
   },
 
   output: {


### PR DESCRIPTION
Added a new hooks `useQueryParam` and `usePathParam` to access and update query and path params respectively in current route. Changes include —

- Two new hooks
- Example to demonstrate hooks usage
- Unit tests
- API docs


```js
import { useQueryParam } from 'react-resource-router';

// Current route in address bar — /home/projects?foo=bar

export const MyComponent = () => {
  const [foo, setFoo] = useQueryParam('foo');
  // => foo will have the value 'bar'

  const clickHandler = () => {
    setFoo('baz');
    // => Will update current route to /home/projects?foo=baz
  };

  return (
    <div>
      <p>Hello World!</p>
      <button onClick={clickHandler}>Update param</button>
    </div>
  );
};
```

```js
import { usePathParam } from 'react-resource-router';

// path — /projects/:projectId/board/:boardId

// Current route in address bar — /projects/123/board/456?foo=bar

export const MyComponent = () => {
  const [projectId, setProjectId] = usePathParam('foo');
  // => projectId will have the value '123'

  const clickHandler = () => {
    setProjectId('xyz');
    // => Will update current route to /projects/xyz/board/456?foo=bar
  };

  return (
    <div>
      <p>Hello World!</p>
      <button onClick={clickHandler}>Update param</button>
    </div>
  );
};
```