### PR TITLE
Add `basePath` support

### DIFF
--- a/docs/api/components.md
+++ b/docs/api/components.md
@@ -33,6 +33,7 @@ import { appRoutes } from './routing';
 | ----------------- | ----------------- | -------------------------------------------------------------------------------------------------- |
 | `routes`          | `Routes[]`        | Your application's routes                                                                          |
 | `history`         | `History`         | The history instance for the router                                                                |
+| `basePath`        | `string`          | Base path string that will get prepended to all route paths                                        |
 | `resourceContext` | `ResourceContext` | Static contextual data that will be provided to all your resources' `getKey` and `getData` methods |
 | `resourceData`    | `ResourceData`    | Pre-resolved resource data. When provided, the router will not request resources on mount          |
 
@@ -58,10 +59,11 @@ export const ServerApp = () => (
 
 ### StaticRouter props
 
-| prop       | type       | description                                             |
-| ---------- | ---------- | ------------------------------------------------------- |
-| `routes`   | `Routes[]` | Your application's routes                               |
-| `location` | `string`   | The string representation of the app's current location |
+| prop       | type       | description                                                 |
+| ---------- | ---------- | ----------------------------------------------------------- |
+| `routes`   | `Routes[]` | Your application's routes                                   |
+| `location` | `string`   | The string representation of the app's current location     |
+| `basePath` | `string`   | Base path string that will get prepended to all route paths |
 
 ## MemoryRouter
 
@@ -96,10 +98,11 @@ it('should send right props after render with routes', () => {
 
 ### MemoryRouter props
 
-| prop       | type       | description                                             |
-| ---------- | ---------- | ------------------------------------------------------- |
-| `routes`   | `Routes[]` | Your application's routes                               |
-| `location` | `string`   | The string representation of the app's current location |
+| prop       | type       | description                                                 |
+| ---------- | ---------- | ----------------------------------------------------------- |
+| `routes`   | `Routes[]` | Your application's routes                                   |
+| `location` | `string`   | The string representation of the app's current location     |
+| `basePath` | `string`   | Base path string that will get prepended to all route paths |
 
 ## Link component
 

--- a/docs/api/utilities.md
+++ b/docs/api/utilities.md
@@ -30,10 +30,13 @@ Utility to create custom router contexts to be passed to resources.
 ```js
 import { myRoute } from '../routing';
 
-const basePath = '/base';
-const params = { id: '1' };
-const query = { order: 'asc' };
-const routerContext = createRouterContext(myRoute, params, query, basePath);
+const options = {
+  params: { id: '1' },
+  query: { order: 'asc' },
+  basePath: '/base',
+};
+
+const routerContext = createRouterContext(myRoute, options);
 ```
 
 ## matchRoute

--- a/docs/api/utilities.md
+++ b/docs/api/utilities.md
@@ -30,9 +30,10 @@ Utility to create custom router contexts to be passed to resources.
 ```js
 import { myRoute } from '../routing';
 
+const basePath = '/base';
 const params = { id: '1' };
 const query = { order: 'asc' };
-const routerContext = createRouterContext(myRoute, params, query);
+const routerContext = createRouterContext(myRoute, params, query, basePath);
 ```
 
 ## matchRoute
@@ -42,6 +43,7 @@ If you ever need to match the current route outside of the router itself, you ca
 ```js
 import { appRoutes } from '../routing';
 
+const basePath = '/base';
 const { pathname, search } = window.location;
-const matchedRoute = matchRoute(routes, pathname, search);
+const matchedRoute = matchRoute(routes, pathname, search, basePath);
 ```

--- a/docs/resources/usage.md
+++ b/docs/resources/usage.md
@@ -62,7 +62,7 @@ import { blogPostRoute } from '../routing';
 
 export const PrefetchBlogPost = ({ id }) => {
   const { refresh } = useResource(blogPostResource, {
-    routerContext: createRouterContext(blogPostRoute, { id }),
+    routerContext: createRouterContext(blogPostRoute, { params: { id } }),
   });
 
   useEffect(() => {

--- a/examples/basic-routing/about.tsx
+++ b/examples/basic-routing/about.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import { Link } from 'react-resource-router';
 
-const baseURL = 'basic-routing';
-
 export const About = () => (
   <div>
     <h1>About</h1>
-    <Link to={`/${baseURL}`}>Go to home</Link>
+    <Link to={'/'}>Go to home</Link>
   </div>
 );

--- a/examples/basic-routing/home.tsx
+++ b/examples/basic-routing/home.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import { Link } from 'react-resource-router';
 
-const baseURL = 'basic-routing';
-
 export const Home = () => (
   <div>
     <h1>Home</h1>
-    <Link to={`/${baseURL}/about`}>Go to about</Link>
+    <Link to={'/about'}>Go to about</Link>
   </div>
 );

--- a/examples/basic-routing/index.tsx
+++ b/examples/basic-routing/index.tsx
@@ -12,19 +12,17 @@ import { About } from './about';
 
 const myHistory = createBrowserHistory();
 
-const baseURL = 'basic-routing';
-
 const appRoutes = [
   {
     name: 'home',
-    path: `/${baseURL}`,
+    path: '/',
     exact: true,
     component: Home,
     navigation: null,
   },
   {
     name: 'about',
-    path: `/${baseURL}/about`,
+    path: '/about',
     exact: true,
     component: About,
     navigation: null,
@@ -33,7 +31,7 @@ const appRoutes = [
 
 const App = () => {
   return (
-    <Router routes={appRoutes} history={myHistory}>
+    <Router routes={appRoutes} history={myHistory} basename="/basic-routing">
       <RouteComponent />
     </Router>
   );

--- a/examples/basic-routing/index.tsx
+++ b/examples/basic-routing/index.tsx
@@ -31,7 +31,7 @@ const appRoutes = [
 
 const App = () => {
   return (
-    <Router routes={appRoutes} history={myHistory} basename="/basic-routing">
+    <Router routes={appRoutes} history={myHistory} basePath="/basic-routing">
       <RouteComponent />
     </Router>
   );

--- a/examples/hooks/home.tsx
+++ b/examples/hooks/home.tsx
@@ -1,17 +1,13 @@
 import React from 'react';
 import { Link } from 'react-resource-router';
 
-const baseURL = '/hooks';
-
 const Home = () => {
   return (
     <div>
       <h1>Available Hooks</h1>
-      <Link to={`${baseURL}/query-param?foo=abc&bar=xyz#abc`}>
-        useQueryParam
-      </Link>
+      <Link to={'/query-param?foo=abc&bar=xyz#abc'}>useQueryParam</Link>
       <br />
-      <Link to={`${baseURL}/path-param/hello/world#abc?foo=abc&bar=xyz`}>
+      <Link to={'/path-param/hello/world#abc?foo=abc&bar=xyz'}>
         usePathParam
       </Link>
     </div>

--- a/examples/hooks/index.tsx
+++ b/examples/hooks/index.tsx
@@ -39,7 +39,7 @@ const appRoutes = [
 
 const App = () => {
   return (
-    <Router routes={appRoutes} history={myHistory} basename="/hooks">
+    <Router routes={appRoutes} history={myHistory} basePath="/hooks">
       <RouteComponent />
     </Router>
   );

--- a/examples/hooks/index.tsx
+++ b/examples/hooks/index.tsx
@@ -13,26 +13,24 @@ import PathParamExample from './use-path-param';
 
 const myHistory = createBrowserHistory();
 
-const baseURL = '/hooks';
-
 const appRoutes = [
   {
     name: 'home',
-    path: `${baseURL}`,
+    path: '/',
     exact: true,
     component: Home,
     navigation: null,
   },
   {
     name: 'query-param',
-    path: `${baseURL}/query-param`,
+    path: '/query-param',
     exact: true,
     component: QueryParamExample,
     navigation: null,
   },
   {
     name: 'path-param',
-    path: `${baseURL}/path-param/:foo/:bar`,
+    path: '/path-param/:foo/:bar',
     exact: true,
     component: PathParamExample,
     navigation: null,
@@ -41,7 +39,7 @@ const appRoutes = [
 
 const App = () => {
   return (
-    <Router routes={appRoutes} history={myHistory}>
+    <Router routes={appRoutes} history={myHistory} basename="/hooks">
       <RouteComponent />
     </Router>
   );

--- a/examples/hooks/use-path-param.tsx
+++ b/examples/hooks/use-path-param.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { Link, usePathParam } from 'react-resource-router';
 
-const baseURL = '/hooks';
-
 const randomStr = (length: number) => {
   let result = '';
   const characters = 'abcdefghijklmnopqrstuvwxyz';
@@ -92,7 +90,7 @@ const PathParamExample = () => {
       <UpdateButton for={'foo'} />
       <ComponentBar />
       <UpdateButton for={'bar'} />
-      <Link to={`${baseURL}`}>Go back to list of hooks</Link>
+      <Link to={'/'}>Go back to list of hooks</Link>
     </div>
   );
 };

--- a/examples/hooks/use-query-param.tsx
+++ b/examples/hooks/use-query-param.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { Link, useQueryParam } from 'react-resource-router';
 
-const baseURL = '/hooks';
-
 const randomStr = (length: number) => {
   let result = '';
   const characters = 'abcdefghijklmnopqrstuvwxyz';
@@ -93,7 +91,7 @@ const QueryParamExample = () => {
       <UpdateButton for={'foo'} />
       <ComponentBar />
       <UpdateButton for={'bar'} />
-      <Link to={`${baseURL}`}>Go back to list of hooks</Link>
+      <Link to={'/'}>Go back to list of hooks</Link>
     </div>
   );
 };

--- a/examples/routing-with-resources/about.tsx
+++ b/examples/routing-with-resources/about.tsx
@@ -9,13 +9,11 @@ export const aboutResource = createResource({
     const response = await fetch(
       'https://dog.ceo/api/breed/schnauzer/images/random'
     );
-    const result:{ message: string} = await response.json();
+    const result: { message: string } = await response.json();
 
     return result;
   },
 });
-
-const baseURL = 'basic-routing-with-resources';
 
 export const About = () => {
   // eslint-disable-next-line
@@ -24,7 +22,7 @@ export const About = () => {
   return (
     <div>
       <h1>About</h1>
-      <Link to={`/${baseURL}`}>Go to home</Link>
+      <Link to={'/'}>Go to home</Link>
       <section>
         <p>A picture of a schnauzer</p>
         <section>

--- a/examples/routing-with-resources/home.tsx
+++ b/examples/routing-with-resources/home.tsx
@@ -7,13 +7,11 @@ export const homeResource = createResource({
   maxAge: 0,
   getData: async () => {
     const response = await fetch('https://dog.ceo/api/breeds/image/random');
-    const result:{ message: string} = await response.json();
+    const result: { message: string } = await response.json();
 
     return result;
   },
 });
-
-const baseURL = 'basic-routing-with-resources';
 
 export const Home = () => {
   // eslint-disable-next-line
@@ -22,7 +20,7 @@ export const Home = () => {
   return (
     <div>
       <h1>Home</h1>
-      <Link to={`/${baseURL}/about`}>Go to about</Link>
+      <Link to={'/about'}>Go to about</Link>
       <section>
         <p>A random picture of a cute dog</p>
         <section>

--- a/examples/routing-with-resources/index.html
+++ b/examples/routing-with-resources/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Example - Basic Routing with Resources</title>
+    <title>Example - Routing with Resources</title>
   </head>
 
   <body>

--- a/examples/routing-with-resources/index.tsx
+++ b/examples/routing-with-resources/index.tsx
@@ -12,12 +12,10 @@ import { About, aboutResource } from './about';
 
 const myHistory = createBrowserHistory();
 
-const baseURL = 'basic-routing-with-resources';
-
 const appRoutes = [
   {
     name: 'home',
-    path: `/${baseURL}`,
+    path: '/',
     exact: true,
     component: Home,
     navigation: null,
@@ -25,7 +23,7 @@ const appRoutes = [
   },
   {
     name: 'about',
-    path: `/${baseURL}/about`,
+    path: '/about',
     exact: true,
     component: About,
     navigation: null,
@@ -35,7 +33,11 @@ const appRoutes = [
 
 const App = () => {
   return (
-    <Router routes={appRoutes} history={myHistory}>
+    <Router
+      routes={appRoutes}
+      history={myHistory}
+      basename="/routing-with-resources"
+    >
       <RouteComponent />
     </Router>
   );

--- a/examples/routing-with-resources/index.tsx
+++ b/examples/routing-with-resources/index.tsx
@@ -36,7 +36,7 @@ const App = () => {
     <Router
       routes={appRoutes}
       history={myHistory}
-      basename="/routing-with-resources"
+      basePath="/routing-with-resources"
     >
       <RouteComponent />
     </Router>

--- a/src/__tests__/integration/test.tsx
+++ b/src/__tests__/integration/test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+
+import { mount } from 'enzyme';
+import * as historyHelper from 'history';
+import { defaultRegistry } from 'react-sweet-state';
+
+import { Router, RouterActions } from '../../controllers';
+import { RouterActionsType } from '../../controllers/router-store/types';
+
+const mockLocation = {
+  pathname: '/projects/123/board/456',
+  search: '?foo=hello&bar=world',
+  hash: '#hash',
+};
+
+const mockRoutes = [
+  {
+    path: '/projects/:projectId/board/:boardId',
+    component: () => null,
+    name: '',
+  },
+  {
+    path: '/anotherpath',
+    component: () => null,
+    name: '',
+  },
+];
+
+const historyBuildOptions = {
+  initialEntries: [
+    `${mockLocation.pathname}${mockLocation.search}${mockLocation.hash}`,
+  ],
+};
+
+let history = historyHelper.createMemoryHistory(historyBuildOptions);
+let historyPushSpy = jest.spyOn(history, 'push');
+let historyReplaceSpy = jest.spyOn(history, 'replace');
+const nextTick = () => new Promise(resolve => setTimeout(resolve));
+
+describe('<Router /> integration tests', () => {
+  beforeEach(() => {
+    history = historyHelper.createMemoryHistory(historyBuildOptions);
+    historyPushSpy = jest.spyOn(history, 'push');
+    historyReplaceSpy = jest.spyOn(history, 'replace');
+  });
+
+  afterEach(() => {
+    defaultRegistry.stores.clear();
+    jest.resetAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  it('should send the right path to history API', async () => {
+    let _routerActions = {} as RouterActionsType;
+    mount(
+      <Router routes={mockRoutes} history={history}>
+        <RouterActions>
+          {routerActions => {
+            _routerActions = routerActions;
+
+            return null;
+          }}
+        </RouterActions>
+      </Router>
+    );
+
+    _routerActions.push('/hello');
+    await nextTick();
+    expect(historyPushSpy).toBeCalledWith(`/hello`);
+
+    _routerActions.replace('/world');
+    await nextTick();
+    expect(historyReplaceSpy).toBeCalledWith(`/world`);
+  });
+
+  it('should send the right path to history API when basePath is set', async () => {
+    let _routerActions = {} as RouterActionsType;
+    mount(
+      <Router routes={mockRoutes} history={history} basePath="/base">
+        <RouterActions>
+          {routerActions => {
+            _routerActions = routerActions;
+
+            return null;
+          }}
+        </RouterActions>
+      </Router>
+    );
+
+    _routerActions.push('/hello');
+    await nextTick();
+    expect(historyPushSpy).toBeCalledWith(`/base/hello`);
+
+    _routerActions.replace('/world');
+    await nextTick();
+    expect(historyReplaceSpy).toBeCalledWith(`/base/world`);
+  });
+});

--- a/src/__tests__/unit/common/utils/match-route/test.ts
+++ b/src/__tests__/unit/common/utils/match-route/test.ts
@@ -47,7 +47,7 @@ describe('matchRoute', () => {
 
   describe('pathname with basePath', () => {
     it('should match a pathname when basePath is empty', () => {
-      const route = { path: '/foo/:bar', component: Noop, basePath: '' };
+      const route = { path: '/foo/:bar', component: Noop };
       expect(
         // @ts-ignore
         matchRoute([route], '/foo/abc', DEFAULT_QUERY_PARAMS)
@@ -73,10 +73,11 @@ describe('matchRoute', () => {
     });
 
     it('should match a basePath+pathname without a query string', () => {
-      const route = { path: '/foo/:bar', component: Noop, basePath: '/base' };
+      const route = { path: '/foo/:bar', component: Noop };
+      const basePath = '/base';
       expect(
         // @ts-ignore
-        matchRoute([route], '/base/foo/abc', DEFAULT_QUERY_PARAMS)
+        matchRoute([route], '/base/foo/abc', DEFAULT_QUERY_PARAMS, basePath)
       ).toEqual({
         route,
         match: {
@@ -90,27 +91,33 @@ describe('matchRoute', () => {
 
       expect(
         // @ts-ignore
-        matchRoute([route], '/foo/abc', DEFAULT_QUERY_PARAMS)
+        matchRoute([route], '/foo/abc', DEFAULT_QUERY_PARAMS, basePath)
       ).toBeNull();
       expect(
         // @ts-ignore
-        matchRoute([route], '/base/baz/abc', DEFAULT_QUERY_PARAMS)
+        matchRoute([route], '/base/baz/abc', DEFAULT_QUERY_PARAMS, basePath)
       ).toBeNull();
     });
 
     it('should return the first route that is a match', () => {
-      const routeA = { path: '/foo/:bar', component: Noop, basePath: '/base' };
-      const routeB = { path: '/foo/:baz', component: Noop, basePath: '/base' };
+      const routeA = { path: '/foo/:bar', component: Noop };
+      const routeB = { path: '/foo/:baz', component: Noop };
+      const basePath = '/base';
       expect(
-        // @ts-ignore
-        matchRoute([routeA, routeB], '/base/foo/abc', DEFAULT_QUERY_PARAMS)
+        matchRoute(
+          // @ts-ignore
+          [routeA, routeB],
+          '/base/foo/abc',
+          DEFAULT_QUERY_PARAMS,
+          basePath
+        )
       ).toMatchObject({
         route: routeA,
       });
 
       expect(
         // @ts-ignore
-        matchRoute([routeB], '/base/foo/abc', DEFAULT_QUERY_PARAMS)
+        matchRoute([routeB], '/base/foo/abc', DEFAULT_QUERY_PARAMS, basePath)
       ).toMatchObject({
         route: routeB,
       });

--- a/src/__tests__/unit/common/utils/match-route/test.ts
+++ b/src/__tests__/unit/common/utils/match-route/test.ts
@@ -45,6 +45,78 @@ describe('matchRoute', () => {
     });
   });
 
+  describe('pathname with basePath', () => {
+    it('should match a pathname when basePath is empty', () => {
+      const route = { path: '/foo/:bar', component: Noop, basePath: '' };
+      expect(
+        // @ts-ignore
+        matchRoute([route], '/foo/abc', DEFAULT_QUERY_PARAMS)
+      ).toEqual({
+        route,
+        match: {
+          params: { bar: 'abc' },
+          isExact: true,
+          path: '/foo/:bar',
+          query: {},
+          url: '/foo/abc',
+        },
+      });
+
+      expect(
+        // @ts-ignore
+        matchRoute([route], '/hello/foo/abc', DEFAULT_QUERY_PARAMS)
+      ).toBeNull();
+      expect(
+        // @ts-ignore
+        matchRoute([route], '/baz/abc', DEFAULT_QUERY_PARAMS)
+      ).toBeNull();
+    });
+
+    it('should match a basePath+pathname without a query string', () => {
+      const route = { path: '/foo/:bar', component: Noop, basePath: '/base' };
+      expect(
+        // @ts-ignore
+        matchRoute([route], '/base/foo/abc', DEFAULT_QUERY_PARAMS)
+      ).toEqual({
+        route,
+        match: {
+          params: { bar: 'abc' },
+          isExact: true,
+          path: '/base/foo/:bar',
+          query: {},
+          url: '/base/foo/abc',
+        },
+      });
+
+      expect(
+        // @ts-ignore
+        matchRoute([route], '/foo/abc', DEFAULT_QUERY_PARAMS)
+      ).toBeNull();
+      expect(
+        // @ts-ignore
+        matchRoute([route], '/base/baz/abc', DEFAULT_QUERY_PARAMS)
+      ).toBeNull();
+    });
+
+    it('should return the first route that is a match', () => {
+      const routeA = { path: '/foo/:bar', component: Noop, basePath: '/base' };
+      const routeB = { path: '/foo/:baz', component: Noop, basePath: '/base' };
+      expect(
+        // @ts-ignore
+        matchRoute([routeA, routeB], '/base/foo/abc', DEFAULT_QUERY_PARAMS)
+      ).toMatchObject({
+        route: routeA,
+      });
+
+      expect(
+        // @ts-ignore
+        matchRoute([routeB], '/base/foo/abc', DEFAULT_QUERY_PARAMS)
+      ).toMatchObject({
+        route: routeB,
+      });
+    });
+  });
+
   describe('query', () => {
     it('should match query config requiring query name to be present', () => {
       const route = {

--- a/src/__tests__/unit/common/utils/router-context/test.tsx
+++ b/src/__tests__/unit/common/utils/router-context/test.tsx
@@ -22,7 +22,7 @@ const mockLocation = {
 
 describe('Router findRouterContext util', () => {
   it('should return the route match', () => {
-    const context = findRouterContext(mockRoutes, mockLocation);
+    const context = findRouterContext(mockRoutes, { location: mockLocation });
 
     expect(context).toEqual({
       route: mockRoutes[2],
@@ -41,7 +41,9 @@ describe('Router findRouterContext util', () => {
       pathname: '/unknown',
     };
 
-    const context = findRouterContext(mockRoutes, unknownLocation);
+    const context = findRouterContext(mockRoutes, {
+      location: unknownLocation,
+    });
 
     expect(context).toEqual({
       route: DEFAULT_ROUTE,
@@ -58,7 +60,7 @@ describe('Router createRouterContext util', () => {
       component: mockComponent,
       name: 'foo',
     };
-    const context = createRouterContext(route, { page: 'cool' });
+    const context = createRouterContext(route, { params: { page: 'cool' } });
 
     expect(context).toEqual({
       route,
@@ -78,7 +80,9 @@ describe('Router createRouterContext util', () => {
       component: mockComponent,
       name: 'foo',
     };
-    const context = createRouterContext(route, {}, { order: '1', iam: 'cool' });
+    const context = createRouterContext(route, {
+      query: { order: '1', iam: 'cool' },
+    });
 
     expect(context).toEqual({
       route,

--- a/src/__tests__/unit/controllers/hooks/resource-store/test.tsx
+++ b/src/__tests__/unit/controllers/hooks/resource-store/test.tsx
@@ -226,7 +226,9 @@ describe('useResource hook', () => {
         <MockComponent page="page1">
           {({ page }: { page: string }) => {
             const resource = useResource(mockRes, {
-              routerContext: createRouterContext(mockRoute, { page }),
+              routerContext: createRouterContext(mockRoute, {
+                params: { page },
+              }),
             });
             resourceResponse = resource;
 

--- a/src/__tests__/unit/controllers/router-store/test.tsx
+++ b/src/__tests__/unit/controllers/router-store/test.tsx
@@ -38,11 +38,13 @@ const mockHistory = {
 
 const mockRoutes = [
   {
+    basePath: '',
     path: '/pathname',
     component: () => <div>path</div>,
     name: '',
   },
   {
+    basePath: '',
     path: '/blah',
     component: () => <div>path</div>,
     name: '',

--- a/src/__tests__/unit/controllers/router-store/test.tsx
+++ b/src/__tests__/unit/controllers/router-store/test.tsx
@@ -38,13 +38,11 @@ const mockHistory = {
 
 const mockRoutes = [
   {
-    basePath: '',
     path: '/pathname',
     component: () => <div>path</div>,
     name: '',
   },
   {
-    basePath: '',
     path: '/blah',
     component: () => <div>path</div>,
     name: '',

--- a/src/__tests__/unit/controllers/router-store/utils/test.ts
+++ b/src/__tests__/unit/controllers/router-store/utils/test.ts
@@ -3,6 +3,7 @@ import {
   isAbsolutePath,
   isExternalAbsolutePath,
   updateQueryParams,
+  sanitizePath,
 } from '../../../../../controllers/router-store/utils/path-utils';
 
 describe('path utils', () => {
@@ -142,6 +143,32 @@ describe('path utils', () => {
       const expectedOutput = '/browse?foo=newVal#abc';
 
       expect(updateQueryParams(location, query)).toEqual(expectedOutput);
+    });
+  });
+
+  describe('sanitizePath', () => {
+    it('should sanitize path + basePath', () => {
+      const path = '/path';
+      const basePath = '/base';
+
+      const expectedOutput = '/base/path';
+      expect(sanitizePath(path, basePath)).toEqual(expectedOutput);
+    });
+
+    it('should sanitize path without basePath', () => {
+      const path = '/path';
+      const basePath = '';
+
+      const expectedOutput = '/path';
+      expect(sanitizePath(path, basePath)).toEqual(expectedOutput);
+    });
+
+    it('should format the slashes before appending', () => {
+      const path = 'path';
+      const basePath = 'base';
+
+      const expectedOutput = '/base/path';
+      expect(sanitizePath(path, basePath)).toEqual(expectedOutput);
     });
   });
 });

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -144,8 +144,6 @@ export type RouterContext = {
  * Base type for route, which doesn't contain implementation details
  */
 export type InvariantRoute = {
-  /* Base prefix that gets appended to all paths */
-  basePath?: string;
   path: string;
   exact?: boolean;
 
@@ -273,4 +271,15 @@ export type MemoryRouterProps = {
   children: ReactNode;
   resourceData?: ResourceStoreData;
   resourceContext?: ResourceStoreContext;
+};
+
+export type CreateRouterContextOptions = {
+  params?: MatchParams;
+  query?: Query;
+  basePath?: string;
+};
+
+export type FindRouterContextOptions = {
+  location: Location;
+  basePath?: string;
 };

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -144,6 +144,8 @@ export type RouterContext = {
  * Base type for route, which doesn't contain implementation details
  */
 export type InvariantRoute = {
+  /* Base prefix that gets appended to all paths */
+  basePath?: string;
   path: string;
   exact?: boolean;
 
@@ -264,6 +266,7 @@ export type HistoryActions = {
 };
 
 export type MemoryRouterProps = {
+  basePath?: string;
   isStatic?: boolean;
   location?: string;
   routes: Routes;

--- a/src/common/utils/match-route/index.ts
+++ b/src/common/utils/match-route/index.ts
@@ -97,7 +97,8 @@ const matchQuery = (
 const matchRoute = <T extends Routes | InvariantRoutes>(
   routes: T,
   pathname: string,
-  queryParams: MatchParams
+  queryParams: MatchParams,
+  basePath = ''
 ): (T extends Routes ? MatchedRoute : MatchedInvariantRoute) | null => {
   const queryParamObject =
     typeof queryParams === 'string'
@@ -107,7 +108,11 @@ const matchRoute = <T extends Routes | InvariantRoutes>(
 
   routes.some(route => {
     const pathMatch = route.path
-      ? matchPath(pathname, route)
+      ? matchPath(pathname, {
+          path: route.path,
+          exact: route.exact,
+          basePath,
+        })
       : computeRootMatch(pathname);
     let match = pathMatch;
 
@@ -130,11 +135,14 @@ const matchRoute = <T extends Routes | InvariantRoutes>(
 export const matchInvariantRoute = (
   routes: InvariantRoutes,
   pathname: string,
-  queryParams: MatchParams
-): MatchedInvariantRoute | null => matchRoute(routes, pathname, queryParams);
+  queryParams: MatchParams,
+  basePath = ''
+): MatchedInvariantRoute | null =>
+  matchRoute(routes, pathname, queryParams, basePath);
 
 export default (
   routes: Routes,
   pathname: string,
-  queryParams: MatchParams
-): MatchedRoute | null => matchRoute(routes, pathname, queryParams);
+  queryParams: MatchParams,
+  basePath = ''
+): MatchedRoute | null => matchRoute(routes, pathname, queryParams, basePath);

--- a/src/common/utils/match-route/matchPath.ts
+++ b/src/common/utils/match-route/matchPath.ts
@@ -36,8 +36,14 @@ function matchPath(
     options = { path: options };
   }
 
-  const { path: p, exact = false, strict = false, sensitive = false } = options;
-  const paths = [].concat(p);
+  const {
+    path: p,
+    exact = false,
+    strict = false,
+    sensitive = false,
+    basePath = '',
+  } = options;
+  const paths = [].concat(basePath + p);
 
   return paths.reduce((matched: any, path: any) => {
     if (!path && path !== '') return null;

--- a/src/common/utils/router-context/index.ts
+++ b/src/common/utils/router-context/index.ts
@@ -15,10 +15,11 @@ import generatePath from '../generate-path';
 export const createRouterContext = (
   route: Route,
   params: MatchParams = {},
-  query: Query = {}
+  query: Query = {},
+  basePath = ''
 ): RouterContext => {
   const pathname = generatePath(route.path, params);
-  const matchedRoute = matchRoute([route], pathname, query);
+  const matchedRoute = matchRoute([route], pathname, query, basePath);
 
   return {
     route,
@@ -29,11 +30,12 @@ export const createRouterContext = (
 
 export const findRouterContext = (
   routes: Routes,
-  location: Location
+  location: Location,
+  basePath = ''
 ): RouterContext => {
   const { pathname, search } = location;
   const query = qs.parse(search) as Query;
-  const matchedRoute = matchRoute(routes, pathname, query);
+  const matchedRoute = matchRoute(routes, pathname, query, basePath);
 
   return {
     query,

--- a/src/common/utils/router-context/index.ts
+++ b/src/common/utils/router-context/index.ts
@@ -2,22 +2,21 @@ import { qs } from 'url-parse';
 
 import { DEFAULT_MATCH, DEFAULT_ROUTE } from '../../constants';
 import {
-  Location,
-  MatchParams,
   Query,
   Route,
   Routes,
   RouterContext,
+  CreateRouterContextOptions,
+  FindRouterContextOptions,
 } from '../../types';
 import matchRoute from '../match-route';
 import generatePath from '../generate-path';
 
 export const createRouterContext = (
   route: Route,
-  params: MatchParams = {},
-  query: Query = {},
-  basePath = ''
+  options: CreateRouterContextOptions = {}
 ): RouterContext => {
+  const { params = {}, query = {}, basePath = '' } = options;
   const pathname = generatePath(route.path, params);
   const matchedRoute = matchRoute([route], pathname, query, basePath);
 
@@ -30,9 +29,9 @@ export const createRouterContext = (
 
 export const findRouterContext = (
   routes: Routes,
-  location: Location,
-  basePath = ''
+  options: FindRouterContextOptions
 ): RouterContext => {
+  const { location, basePath = '' } = options;
   const { pathname, search } = location;
   const query = qs.parse(search) as Query;
   const matchedRoute = matchRoute(routes, pathname, query, basePath);

--- a/src/controllers/memory-router/index.tsx
+++ b/src/controllers/memory-router/index.tsx
@@ -10,11 +10,13 @@ import { MemoryRouterProps } from '../../common/types';
 const getRouterProps = (memoryRouterProps: MemoryRouterProps) => {
   const {
     isStatic = false,
+    basePath,
     routes,
     resourceData,
     resourceContext,
   } = memoryRouterProps;
   let routerProps: Partial<RouterProps> = {
+    basePath,
     routes,
     isStatic,
   };

--- a/src/controllers/router-store/index.tsx
+++ b/src/controllers/router-store/index.tsx
@@ -65,7 +65,10 @@ const actions: AllRouterActions = {
       ...initialProps
     } = props;
     const { history, isStatic } = initialProps;
-    const routerContext = findRouterContext(routes, history.location, basePath);
+    const routerContext = findRouterContext(routes, {
+      location: history.location,
+      basePath,
+    });
 
     setState({
       ...initialProps,
@@ -94,7 +97,10 @@ const actions: AllRouterActions = {
       ...initialProps
     } = props;
     const { history, routes } = initialProps;
-    const routerContext = findRouterContext(routes, history.location, basePath);
+    const routerContext = findRouterContext(routes, {
+      location: history.location,
+      basePath,
+    });
 
     setState({
       ...initialProps,
@@ -134,7 +140,7 @@ const actions: AllRouterActions = {
     const { history, routes, basePath } = getState();
 
     const stopListening = history.listen(async (location, action) => {
-      const nextContext = findRouterContext(routes, location, basePath);
+      const nextContext = findRouterContext(routes, { location, basePath });
       const {
         match: currentMatch,
         route: currentRoute,

--- a/src/controllers/router-store/index.tsx
+++ b/src/controllers/router-store/index.tsx
@@ -46,6 +46,7 @@ export const INITIAL_STATE: EntireRouterState = {
   match: DEFAULT_MATCH,
   action: DEFAULT_ACTION,
   unlisten: null,
+  basePath: '',
   isStatic: false,
   shouldUseSuspense: false,
 };
@@ -56,13 +57,29 @@ const actions: AllRouterActions = {
    *
    */
   bootstrapStore: props => ({ setState, dispatch }) => {
-    const { resourceContext, resourceData, ...initialProps } = props;
-    const { history, routes, isStatic } = initialProps;
-    const routerContext = findRouterContext(routes, history.location);
+    const {
+      resourceContext,
+      resourceData,
+      basePath = '',
+      routes,
+      ...initialProps
+    } = props;
+    const { history, isStatic } = initialProps;
+    const routesWithBasePath = routes.map(r => ({
+      ...r,
+      basePath,
+    }));
+
+    const routerContext = findRouterContext(
+      routesWithBasePath,
+      history.location
+    );
 
     setState({
       ...initialProps,
       ...routerContext,
+      basePath,
+      routes: routesWithBasePath,
       location: history.location,
       action: history.action,
     });
@@ -78,9 +95,22 @@ const actions: AllRouterActions = {
    * internally. We can remove this when UniversalRouter replaces Router completely.
    */
   bootstrapStoreUniversal: props => ({ setState, dispatch }) => {
-    const { resourceContext, resourceData, ...initialProps } = props;
+    const {
+      resourceContext,
+      resourceData,
+      basePath = '',
+      ...initialProps
+    } = props;
     const { history, routes } = initialProps;
-    const routerContext = findRouterContext(routes, history.location);
+    const routesWithBasePath = routes.map(r => ({
+      ...r,
+      basePath,
+    }));
+
+    const routerContext = findRouterContext(
+      routesWithBasePath,
+      history.location
+    );
 
     setState({
       ...initialProps,
@@ -170,22 +200,21 @@ const actions: AllRouterActions = {
   },
 
   push: path => ({ getState }) => {
-    const { history } = getState();
-
+    const { history, basePath } = getState();
     if (isExternalAbsolutePath(path)) {
       window.location.assign(path as string);
     } else {
-      history.push(getRelativePath(path) as any);
+      history.push(getRelativePath(path, basePath) as any);
     }
   },
 
   replace: path => ({ getState }) => {
-    const { history } = getState();
+    const { history, basePath } = getState();
 
     if (isExternalAbsolutePath(path)) {
       window.location.replace(path as string);
     } else {
-      history.replace(getRelativePath(path) as any);
+      history.replace(getRelativePath(path, basePath) as any);
     }
   },
 
@@ -236,11 +265,15 @@ const actions: AllRouterActions = {
     const {
       history,
       location,
-      route: { path: rawPath },
+      route: { path, basePath },
       match: { params: existingPathParams },
     } = getState();
+    const pathWithBasePath = basePath + path;
     const updatedPathParams = { ...existingPathParams, ...params };
-    const updatedPath = generatePathUsingPathParams(rawPath, updatedPathParams);
+    const updatedPath = generatePathUsingPathParams(
+      pathWithBasePath,
+      updatedPathParams
+    );
     const updatedLocation = { ...location, pathname: updatedPath };
 
     const existingRelativePath = getRelativeURLFromLocation(location);

--- a/src/controllers/router-store/index.tsx
+++ b/src/controllers/router-store/index.tsx
@@ -65,21 +65,13 @@ const actions: AllRouterActions = {
       ...initialProps
     } = props;
     const { history, isStatic } = initialProps;
-    const routesWithBasePath = routes.map(r => ({
-      ...r,
-      basePath,
-    }));
-
-    const routerContext = findRouterContext(
-      routesWithBasePath,
-      history.location
-    );
+    const routerContext = findRouterContext(routes, history.location, basePath);
 
     setState({
       ...initialProps,
       ...routerContext,
       basePath,
-      routes: routesWithBasePath,
+      routes,
       location: history.location,
       action: history.action,
     });
@@ -102,19 +94,12 @@ const actions: AllRouterActions = {
       ...initialProps
     } = props;
     const { history, routes } = initialProps;
-    const routesWithBasePath = routes.map(r => ({
-      ...r,
-      basePath,
-    }));
-
-    const routerContext = findRouterContext(
-      routesWithBasePath,
-      history.location
-    );
+    const routerContext = findRouterContext(routes, history.location, basePath);
 
     setState({
       ...initialProps,
       ...routerContext,
+      basePath,
       location: history.location,
       action: history.action,
     });
@@ -146,10 +131,10 @@ const actions: AllRouterActions = {
    *
    */
   listen: () => ({ getState, setState }) => {
-    const { history, routes } = getState();
+    const { history, routes, basePath } = getState();
 
     const stopListening = history.listen(async (location, action) => {
-      const nextContext = findRouterContext(routes, location);
+      const nextContext = findRouterContext(routes, location, basePath);
       const {
         match: currentMatch,
         route: currentRoute,
@@ -265,8 +250,9 @@ const actions: AllRouterActions = {
     const {
       history,
       location,
-      route: { path, basePath },
+      route: { path },
       match: { params: existingPathParams },
+      basePath,
     } = getState();
     const pathWithBasePath = basePath + path;
     const updatedPathParams = { ...existingPathParams, ...params };

--- a/src/controllers/router-store/types.ts
+++ b/src/controllers/router-store/types.ts
@@ -18,6 +18,7 @@ import {
 import { MemoryHistory } from 'history';
 
 type PublicStateProperties = {
+  basePath: string;
   location: Location;
   query: Query;
   route: Route;
@@ -41,6 +42,7 @@ export type ContainerProps = {
   isStatic?: boolean;
   history: BrowserHistory | MemoryHistory;
   location?: Location;
+  basePath?: string;
   routes: Routes;
   resourceData?: ResourceStoreData;
   resourceContext?: ResourceStoreContext;

--- a/src/controllers/router-store/utils/path-utils.ts
+++ b/src/controllers/router-store/utils/path-utils.ts
@@ -2,6 +2,22 @@ import URL, { qs } from 'url-parse';
 
 import { Href, Location, Query } from '../../../common/types';
 
+const stripTrailingSlash = (path: string) =>
+  path.charAt(path.length - 1) === '/' ? path.slice(0, -1) : path;
+
+const addLeadingSlash = (path: string) =>
+  path.charAt(0) === '/' ? path : '/' + path;
+
+export const sanitizePath = (path: string, prefix = ''): string => {
+  if (prefix) {
+    prefix = stripTrailingSlash(prefix);
+    prefix = addLeadingSlash(prefix);
+    path = addLeadingSlash(path);
+  }
+
+  return prefix + path;
+};
+
 export const isAbsolutePath = (path: string): boolean => {
   const regex = new RegExp('^([a-z]+://|//)', 'i');
 
@@ -19,8 +35,17 @@ export const isExternalAbsolutePath = (path: Href | Location): boolean => {
   return pathHostname !== currentHostname;
 };
 
-export const getRelativePath = (path: Href | Location): string | Location => {
-  if (typeof path !== 'string' || !isAbsolutePath(path)) {
+export const getRelativePath = (
+  path: Href | Location,
+  prefix = ''
+): string | Location => {
+  if (typeof path !== 'string') {
+    return path;
+  }
+
+  if (!isAbsolutePath(path)) {
+    path = sanitizePath(path, prefix);
+
     return path;
   }
 

--- a/src/controllers/router/index.tsx
+++ b/src/controllers/router/index.tsx
@@ -49,12 +49,14 @@ export class Router extends Component<RouterProps> {
       routes,
       history,
       isStatic,
+      basePath,
       resourceContext,
       resourceData,
     } = this.props;
 
     return (
       <RouterContainer
+        basePath={basePath}
         routes={routes}
         history={history}
         isStatic={isStatic}

--- a/src/controllers/router/types.ts
+++ b/src/controllers/router/types.ts
@@ -12,6 +12,7 @@ export type RouterProps = {
   history: BrowserHistory;
   resourceContext?: ResourceStoreContext;
   resourceData?: ResourceStoreData;
+  basePath?: string;
   routes: Routes;
   children: ReactNode;
 };

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -108,13 +108,15 @@ declare export function withRouter<
 declare export function matchRoute(
   routes: Routes,
   pathname: string,
-  queryParams: MatchParams | string
+  queryParams: MatchParams | string,
+  basePath?: string
 ): MatchedRoute | null;
 
 declare export function matchInvariantRoute(
   routes: InvariantRoutes,
   pathname: string,
-  queryParams: MatchParams | string
+  queryParams: MatchParams | string,
+  basePath?: string
 ): MatchedInvariantRoute | null;
 
 declare export function generatePath(
@@ -127,12 +129,14 @@ declare export function createLegacyHistory(): BrowserHistory;
 declare export function createRouterContext(
   route: Route,
   params?: MatchParams,
-  query?: Query
+  query?: Query,
+  basePath?: string
 ): RouterContext;
 
 declare export function findRouterContext(
   routes: Routes,
-  location: Location
+  location: Location,
+  basePath?: string
 ): RouterContext;
 
 /**

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -32,8 +32,10 @@ import type {
   RouterSubscriberProps,
   Routes,
   StaticRouterProps,
+  CreateRouterContextOptions
 } from './types.js.flow';
 
+export * from './utils.js.flow';
 export * from './types.js.flow';
 
 declare export function Link(props: LinkProps): Node;
@@ -105,20 +107,6 @@ declare export function withRouter<
   $Diff<ElementConfig<$Supertype<Component>>, WithRouterProps>
 >;
 
-declare export function matchRoute(
-  routes: Routes,
-  pathname: string,
-  queryParams: MatchParams | string,
-  basePath?: string
-): MatchedRoute | null;
-
-declare export function matchInvariantRoute(
-  routes: InvariantRoutes,
-  pathname: string,
-  queryParams: MatchParams | string,
-  basePath?: string
-): MatchedInvariantRoute | null;
-
 declare export function generatePath(
   pattern: string,
   params?: { [paramName: string]: string | number | boolean | null | void }
@@ -128,15 +116,7 @@ declare export function createLegacyHistory(): BrowserHistory;
 
 declare export function createRouterContext(
   route: Route,
-  params?: MatchParams,
-  query?: Query,
-  basePath?: string
-): RouterContext;
-
-declare export function findRouterContext(
-  routes: Routes,
-  location: Location,
-  basePath?: string
+  options?: CreateRouterContextOptions,
 ): RouterContext;
 
 /**

--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -305,3 +305,14 @@ export type RouterSubscriberProps = {|
     actions: BoundActions<RouterActionsType>
   ) => Node,
 |};
+
+export type CreateRouterContextOptions = {
+  params?: MatchParams;
+  query?: Query;
+  basePath?: string;
+};
+
+export type FindRouterContextOptions = {
+  location: Location;
+  basePath?: string;
+};

--- a/src/utils.js.flow
+++ b/src/utils.js.flow
@@ -9,6 +9,8 @@ import type {
   MatchedRoute,
   MatchParams,
   Routes,
+  FindRouterContextOptions,
+  RouterContext,
 } from './types.js.flow';
 
 declare export function createLegacyHistory(): BrowserHistory;
@@ -19,10 +21,9 @@ declare export function generatePath(
 ): string;
 
 declare export function findRouterContext(
-  location: Location,
   routes: Routes,
-  basePath?: string
-): string;
+  options: FindRouterContextOptions
+): RouterContext;
 
 declare export function matchRoute(
   routes: Routes,

--- a/src/utils.js.flow
+++ b/src/utils.js.flow
@@ -20,17 +20,20 @@ declare export function generatePath(
 
 declare export function findRouterContext(
   location: Location,
-  routes: Routes
+  routes: Routes,
+  basePath?: string
 ): string;
 
 declare export function matchRoute(
   routes: Routes,
   pathname: string,
-  queryParams: MatchParams | string
+  queryParams: MatchParams | string,
+  basePath?: string
 ): MatchedRoute | null;
 
 declare export function matchInvariantRoute(
   routes: InvariantRoutes,
   pathname: string,
-  queryParams: MatchParams | string
+  queryParams: MatchParams | string,
+  basePath?: string
 ): MatchedInvariantRoute | null;


### PR DESCRIPTION
Users can now pass in `basePath` prop and it will get appended to all paths via `<Link />`, `push` and `replace` APIs.

~**Note: Docs update yet to be done.**~ **Docs updated.**