### PR TITLE
Use param hooks allow specifying history update type on set

### DIFF
--- a/docs/api/hooks.md
+++ b/docs/api/hooks.md
@@ -66,6 +66,8 @@ export const RouterActionsHookExample = () => {
 
 You can use the `useQueryParam` hook to access the query params in current route. Pass in `undefined` to remove a query param from the url.
 
+The setter takes two arguments, `(newValue, updateType)` where `updateType` is `'push' | 'replace'` defaulting to `'push'` if not provided.
+
 ```js
 import { useQueryParam } from 'react-resource-router';
 
@@ -75,15 +77,21 @@ export const MyComponent = () => {
   const [foo, setFoo] = useQueryParam('foo');
   // => foo will have the value 'bar'
 
-  const clickHandler = () => {
-    setFoo('baz');
-    // => Will update current route to /home/projects?foo=baz
+  const pushClickHandler = () => {
+    setFoo('baz'); // equivalent to setFoo('baz', 'push')
+    // => Will push current route /home/projects?foo=bar (can use back button)
+  };
+
+  const replaceClickHandler = () => {
+    setFoo('qux', 'replace');
+    // => Will replace current route to /home/projects?foo=qux
   };
 
   return (
     <div>
       <p>Hello World!</p>
-      <button onClick={clickHandler}>Update param</button>
+      <button onClick={pushClickHandler}>Push param</button>
+      <button onClick={replaceClickHandler}>Replace param</button>
     </div>
   );
 };
@@ -92,6 +100,8 @@ export const MyComponent = () => {
 ## usePathParam
 
 You can use the `usePathParam` hook to access the path params in current route. Pass in `undefined` to remove an [optional param](https://github.com/pillarjs/path-to-regexp#optional) from the url.
+
+The setter takes two arguments, `(newValue, updateType)` where `updateType` is `'push' | 'replace'` defaulting to `'push'` if not provided.
 
 ```js
 import { usePathParam } from 'react-resource-router';
@@ -104,10 +114,15 @@ export const MyComponent = () => {
   const [projectId, setProjectId] = usePathParam('projectId');
   // => projectId will have the value '123'
 
-  const clickHandler = () => {
-    setProjectId('222');
-    // => Will update current route to /projects/222/board/456?foo=bar
+  const pushClickHandler = () => {
+    setProjectId('222'); // equivalent to setProject('222', 'push')
+    // => Will push current route /projects/222/board/456?foo=bar (can use back button)
   };
+
+  const replaceClickHandler = () => {
+    setProjectId('333', 'replace');
+    // => Will relace current route to /projects/333/board/456?foo=bar
+  }
 
   return (
     <div>

--- a/examples/hooks/use-path-param.tsx
+++ b/examples/hooks/use-path-param.tsx
@@ -35,6 +35,9 @@ const UpdateButton = ({ for: paramKey = '' }) => {
       }}
     >
       <button onClick={() => setParam(randomStr(5))}>Update {paramKey}</button>
+      <button onClick={() => setParam(randomStr(5), 'replace')}>
+        Replace {paramKey}
+      </button>
     </div>
   );
 };
@@ -52,8 +55,8 @@ const ComponentFoo = () => {
       }}
     >
       <div>
-        I am ComponentFoo that consumes 'foo' query param. My background color
-        changes on every render.
+        I am ComponentFoo that consumes &apos;foo&apos; query param. My
+        background color changes on every render.
       </div>
       <p>foo={foo}</p>
     </div>
@@ -73,8 +76,8 @@ const ComponentBar = () => {
       }}
     >
       <div>
-        I am ComponentBar that consumes 'bar' query param. My background color
-        changes on every render.
+        I am ComponentBar that consumes &apos;bar&apos; query param. My
+        background color changes on every render.
       </div>
       <p>bar={bar}</p>
     </div>

--- a/examples/hooks/use-query-param.tsx
+++ b/examples/hooks/use-query-param.tsx
@@ -35,6 +35,9 @@ const UpdateButton = ({ for: paramKey = '' }) => {
       }}
     >
       <button onClick={() => setParam(randomStr(5))}>Update {paramKey}</button>
+      <button onClick={() => setParam(randomStr(5), 'replace')}>
+        Replace {paramKey}
+      </button>
       <button onClick={() => setParam(undefined)}>Empty {paramKey}</button>
     </div>
   );
@@ -53,8 +56,8 @@ const ComponentFoo = () => {
       }}
     >
       <div>
-        I am ComponentFoo that consumes 'foo' query param. My background color
-        changes on every render.
+        I am ComponentFoo that consumes &apos;foo&apos; query param. My
+        background color changes on every render.
       </div>
       <p>foo={foo}</p>
     </div>
@@ -74,8 +77,8 @@ const ComponentBar = () => {
       }}
     >
       <div>
-        I am ComponentBar that consumes 'bar' query param. My background color
-        changes on every render.
+        I am ComponentBar that consumes &apos;bar&apos; query param. My
+        background color changes on every render.
       </div>
       <p>bar={bar}</p>
     </div>

--- a/src/controllers/hooks/router-store/index.tsx
+++ b/src/controllers/hooks/router-store/index.tsx
@@ -55,7 +55,10 @@ const createPathParamHook = createHook<
  */
 export const useQueryParam = (
   paramKey: string
-): [string | undefined, (qp: string | undefined) => void] => {
+): [
+  string | undefined,
+  (newValue: string | undefined, updateType?: HistoryUpdateType) => void
+] => {
   const [paramVal, routerActions] = createQueryParamHook({ paramKey });
 
   const setQueryParam = React.useCallback(
@@ -73,7 +76,10 @@ export const useQueryParam = (
  */
 export const usePathParam = (
   paramKey: string
-): [string | undefined, (pp: string | undefined) => void] => {
+): [
+  string | undefined,
+  (newValue: string | undefined, updateType?: HistoryUpdateType) => void
+] => {
   const [paramVal, routerActions] = createPathParamHook({ paramKey });
 
   const setPathParam = React.useCallback(

--- a/src/controllers/hooks/router-store/index.tsx
+++ b/src/controllers/hooks/router-store/index.tsx
@@ -10,6 +10,7 @@ import {
   RouterState,
   EntireRouterState,
   AllRouterActions,
+  HistoryUpdateType,
 } from '../../router-store/types';
 
 /**
@@ -58,8 +59,8 @@ export const useQueryParam = (
   const [paramVal, routerActions] = createQueryParamHook({ paramKey });
 
   const setQueryParam = React.useCallback(
-    (newValue: string | undefined) => {
-      routerActions.pushQueryParam({ [paramKey]: newValue });
+    (newValue: string | undefined, updateType?: HistoryUpdateType) => {
+      routerActions.updateQueryParam({ [paramKey]: newValue }, updateType);
     },
     [paramKey, routerActions]
   );
@@ -76,8 +77,8 @@ export const usePathParam = (
   const [paramVal, routerActions] = createPathParamHook({ paramKey });
 
   const setPathParam = React.useCallback(
-    (newValue: string | undefined) => {
-      routerActions.pushPathParam({ [paramKey]: newValue });
+    (newValue: string | undefined, updateType?: HistoryUpdateType) => {
+      routerActions.updatePathParam({ [paramKey]: newValue }, updateType);
     },
     [paramKey, routerActions]
   );

--- a/src/controllers/router-store/index.tsx
+++ b/src/controllers/router-store/index.tsx
@@ -213,7 +213,7 @@ const actions: AllRouterActions = {
     return { query, route, match };
   },
 
-  pushQueryParam: params => ({ getState }) => {
+  updateQueryParam: (params, updateType) => ({ getState }) => {
     const { query: existingQueryParams, history, location } = getState();
     const updatedQueryParams = { ...existingQueryParams, ...params };
     // remove undefined keys
@@ -228,11 +228,11 @@ const actions: AllRouterActions = {
     );
 
     if (updatedPath !== existingPath) {
-      history.push(updatedPath);
+      history[updateType ?? 'push'](updatedPath);
     }
   },
 
-  pushPathParam: params => ({ getState }) => {
+  updatePathParam: (params, updateType) => ({ getState }) => {
     const {
       history,
       location,
@@ -247,7 +247,7 @@ const actions: AllRouterActions = {
     const updatedRelativePath = getRelativeURLFromLocation(updatedLocation);
 
     if (updatedRelativePath !== existingRelativePath) {
-      history.push(updatedRelativePath);
+      history[updateType ?? 'push'](updatedRelativePath);
     }
   },
 };

--- a/src/controllers/router-store/index.tsx
+++ b/src/controllers/router-store/index.tsx
@@ -213,7 +213,7 @@ const actions: AllRouterActions = {
     return { query, route, match };
   },
 
-  updateQueryParam: (params, updateType) => ({ getState }) => {
+  updateQueryParam: (params, updateType = 'push') => ({ getState }) => {
     const { query: existingQueryParams, history, location } = getState();
     const updatedQueryParams = { ...existingQueryParams, ...params };
     // remove undefined keys
@@ -228,11 +228,11 @@ const actions: AllRouterActions = {
     );
 
     if (updatedPath !== existingPath) {
-      history[updateType ?? 'push'](updatedPath);
+      history[updateType](updatedPath);
     }
   },
 
-  updatePathParam: (params, updateType) => ({ getState }) => {
+  updatePathParam: (params, updateType = 'push') => ({ getState }) => {
     const {
       history,
       location,
@@ -247,7 +247,7 @@ const actions: AllRouterActions = {
     const updatedRelativePath = getRelativeURLFromLocation(updatedLocation);
 
     if (updatedRelativePath !== existingRelativePath) {
-      history[updateType ?? 'push'](updatedRelativePath);
+      history[updateType](updatedRelativePath);
     }
   },
 };

--- a/src/controllers/router-store/types.ts
+++ b/src/controllers/router-store/types.ts
@@ -53,6 +53,8 @@ export type UniversalRouterContainerProps = { isGlobal?: boolean } & Omit<
 
 export type RouterAction = Action<EntireRouterState, AllRouterActions>;
 
+export type HistoryUpdateType = 'push' | 'replace';
+
 type PrivateRouterActions = {
   bootstrapStore: (initialState: ContainerProps) => RouterAction;
   bootstrapStoreUniversal: (
@@ -61,12 +63,18 @@ type PrivateRouterActions = {
   requestRouteResources: () => RouterAction;
   listen: () => RouterAction;
   getContext: () => RouterAction;
-  pushQueryParam: (params: {
-    [key: string]: string | undefined;
-  }) => RouterAction;
-  pushPathParam: (params: {
-    [key: string]: string | undefined;
-  }) => RouterAction;
+  updateQueryParam: (
+    params: {
+      [key: string]: string | undefined;
+    },
+    updateType?: HistoryUpdateType
+  ) => RouterAction;
+  updatePathParam: (
+    params: {
+      [key: string]: string | undefined;
+    },
+    updateType?: HistoryUpdateType
+  ) => RouterAction;
 };
 
 type PublicRouterActions = {

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -6,6 +6,10 @@ import type { BoundActions } from 'react-sweet-state';
 import type { BrowserHistory } from 'history/createBrowserHistory';
 
 import type {
+  HistoryAction,
+  HistoryBlocker,
+  HistoryUpdateType,
+  InvariantRoute,
   InvariantRoutes,
   LinkProps,
   Location,
@@ -81,10 +85,10 @@ declare export function useRouterActions(): BoundActions<RouterActionsType>;
 declare export function useResourceStoreContext(): ResourceStoreContext;
 declare export function useQueryParam(
   paramKey: string
-): [string | void, (qp: string | void) => void];
+): [string | void, (newValue: string | void, updateType?: HistoryUpdateType) => void];
 declare export function usePathParam(
   paramKey: string
-): [string | void, (pp: string | void) => void];
+): [string | void, (newValue: string | void, updateType?: HistoryUpdateType) => void];
 
 // Utils
 type WithRouterProps = RouteContext & {|

--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -249,6 +249,8 @@ export type RouterContext = {|
 
 export type HistoryAction = 'PUSH' | 'REPLACE' | 'POP' | '';
 
+export type HistoryUpdateType = 'push' | 'replace';
+
 export type NavigationType = 'container' | 'product';
 
 type NavigationRenderUpdater = (


### PR DESCRIPTION
`useQueryParam` or `usePathParam` hooks when setting the param, the update type (`push` or `update`, default: `push`) can be set to specify the how history is updated.