### PR TITLE
prevent rerenders if hook setters are called with the same value

### DIFF
--- a/src/controllers/router-store/index.tsx
+++ b/src/controllers/router-store/index.tsx
@@ -227,8 +227,6 @@ const actions: AllRouterActions = {
       updatedQueryParams as Query
     );
 
-    console.log('updatedPath', updatedPath);
-
     if (updatedPath !== existingPath) {
       history.push(updatedPath);
     }

--- a/src/controllers/router-store/index.tsx
+++ b/src/controllers/router-store/index.tsx
@@ -221,12 +221,17 @@ const actions: AllRouterActions = {
       key =>
         updatedQueryParams[key] === undefined && delete updatedQueryParams[key]
     );
+    const existingPath = updateQueryParams(location, existingQueryParams);
     const updatedPath = updateQueryParams(
       location,
       updatedQueryParams as Query
     );
 
-    history.push(updatedPath);
+    console.log('updatedPath', updatedPath);
+
+    if (updatedPath !== existingPath) {
+      history.push(updatedPath);
+    }
   },
 
   pushPathParam: params => ({ getState }) => {
@@ -240,7 +245,12 @@ const actions: AllRouterActions = {
     const updatedPath = generatePathUsingPathParams(rawPath, updatedPathParams);
     const updatedLocation = { ...location, pathname: updatedPath };
 
-    history.push(getRelativeURLFromLocation(updatedLocation));
+    const existingRelativePath = getRelativeURLFromLocation(location);
+    const updatedRelativePath = getRelativeURLFromLocation(updatedLocation);
+
+    if (updatedRelativePath !== existingRelativePath) {
+      history.push(updatedRelativePath);
+    }
   },
 };
 


### PR DESCRIPTION
I noticed in the examples that if you click on the "remove param" buttons on the hooks multiple times, the page continues to rerender even though the path hasn't updated.

This PR changes the behavior so we only call `history.push` if the path has changed.