### PR TITLE
Support initial route and link to route

### DIFF
--- a/docs/api/components.md
+++ b/docs/api/components.md
@@ -124,14 +124,16 @@ export const LinkExample = ({ href = '/' }) => {
 
 ### Link props
 
-| prop      | type       | description                                                                |
-| --------- | ---------- | -------------------------------------------------------------------------- |
-| `target`  | `string`   | `<a>`tag target attribute                                                  |
-| `replace` | `boolean`  | Determines if `history.replace` should be called instead of `history.push` |
-| `href`    | `Href`     | The route to navigate to                                                   |
-| `to`      | `Href`     | Alternative to `href`                                                      |
-| `onClick` | `function` | The function to call when the component is clicked                         |
-| `type`    | `string`   | The tag type to render, `a` and `button` are supported                     |
+| prop      | type                        | description                                                                |
+| --------- | --------------------------- | -------------------------------------------------------------------------- |
+| `target`  | `string`                    | `<a>`tag target attribute                                                  |
+| `replace` | `boolean`                   | Determines if `history.replace` should be called instead of `history.push` |
+| `href`    | `string` or `Location`      | The path to navigate to                                                    |
+| `to`      | `Route` or `Promise<Route>` | Links to supplied route                                                    |
+| `onClick` | `function`                  | The function to call when the component is clicked                         |
+| `type`    | `string`                    | The tag type to render, `a` and `button` are supported                     |
+| `params`  | `{ [key]: string }`         | Used with `to` to generate correct path url                                |
+| `query`   | `{ [key]: string }`         | Used with `to` to generate correct query string url                        |
 
 ## Redirect
 
@@ -247,13 +249,15 @@ Actions that communicate with the router's routing functionality are exposed saf
 
 By using either of these you will gain access to the following actions
 
-| prop            | type       | arguments                               | description                                                                                           |
-| --------------- | ---------- | --------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `push`          | `function` | `path: Href` or `Location, state?: any` | Calls `history.push` with the supplied args                                                           |
-| `replace`       | `function` | `path: Href` or `Location, state?: any` | Calls `history.replace` with the supplied args                                                        |
-| `goBack`        | `function` |                                         | Goes to the previous route in history                                                                 |
-| `goForward`     | `function` |                                         | Goes to the next route in history                                                                     |
-| `registerBlock` | `function` | `blocker: HistoryBlocker`               | Custom `history` API that allows you to stop a transition from happening so route changes are stopped |
+| prop            | type       | arguments                                                | description                                                                                           |
+| --------------- | ---------- | -------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `push`          | `function` | `path: Href` or `Location, state?: any`                  | Calls `history.push` with the supplied args                                                           |
+| `pushTo`        | `function` | `route: Route, attributes?: { params?: {}, query?: {} }` | Calls `history.push` generating the path from supplied route and attributes                           |
+| `replace`       | `function` | `path: Href` or `Location, state?: any`                  | Calls `history.replace` with the supplied args                                                        |
+| `replaceTo`     | `function` | `route: Route, attributes?: { params?: {}, query?: {} }` | Calls `history.replace` generating the path from supplied route and attributes                        |
+| `goBack`        | `function` |                                                          | Goes to the previous route in history                                                                 |
+| `goForward`     | `function` |                                                          | Goes to the next route in history                                                                     |
+| `registerBlock` | `function` | `blocker: HistoryBlocker`                                | Custom `history` API that allows you to stop a transition from happening so route changes are stopped |
 
 Here's how you can use the component:
 

--- a/docs/api/components.md
+++ b/docs/api/components.md
@@ -124,16 +124,16 @@ export const LinkExample = ({ href = '/' }) => {
 
 ### Link props
 
-| prop      | type                        | description                                                                |
-| --------- | --------------------------- | -------------------------------------------------------------------------- |
-| `target`  | `string`                    | `<a>`tag target attribute                                                  |
-| `replace` | `boolean`                   | Determines if `history.replace` should be called instead of `history.push` |
-| `href`    | `string` or `Location`      | The path to navigate to                                                    |
-| `to`      | `Route` or `Promise<Route>` | Links to supplied route                                                    |
-| `onClick` | `function`                  | The function to call when the component is clicked                         |
-| `type`    | `string`                    | The tag type to render, `a` and `button` are supported                     |
-| `params`  | `{ [key]: string }`         | Used with `to` to generate correct path url                                |
-| `query`   | `{ [key]: string }`         | Used with `to` to generate correct query string url                        |
+| prop      | type                                    | description                                                                |
+| --------- | --------------------------------------- | -------------------------------------------------------------------------- |
+| `target`  | `string`                                | `<a>`tag target attribute                                                  |
+| `replace` | `boolean`                               | Determines if `history.replace` should be called instead of `history.push` |
+| `href`    | `string`                                | The path to navigate to                                                    |
+| `to`      | `string` or `Route` or `Promise<Route>` | Links to supplied route                                                    |
+| `onClick` | `function`                              | The function to call when the component is clicked                         |
+| `type`    | `string`                                | The tag type to render, `a` and `button` are supported                     |
+| `params`  | `{ [key]: string }`                     | Used with `to` to generate correct path url                                |
+| `query`   | `{ [key]: string }`                     | Used with `to` to generate correct query string url                        |
 
 ## Redirect
 
@@ -251,9 +251,9 @@ By using either of these you will gain access to the following actions
 
 | prop            | type       | arguments                                                | description                                                                                           |
 | --------------- | ---------- | -------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `push`          | `function` | `path: Href` or `Location, state?: any`                  | Calls `history.push` with the supplied args                                                           |
+| `push`          | `function` | `path: Href, state?: any`                                | Calls `history.push` with the supplied args                                                           |
 | `pushTo`        | `function` | `route: Route, attributes?: { params?: {}, query?: {} }` | Calls `history.push` generating the path from supplied route and attributes                           |
-| `replace`       | `function` | `path: Href` or `Location, state?: any`                  | Calls `history.replace` with the supplied args                                                        |
+| `replace`       | `function` | `path: Href, state?: any`                                | Calls `history.replace` with the supplied args                                                        |
 | `replaceTo`     | `function` | `route: Route, attributes?: { params?: {}, query?: {} }` | Calls `history.replace` generating the path from supplied route and attributes                        |
 | `goBack`        | `function` |                                                          | Goes to the previous route in history                                                                 |
 | `goForward`     | `function` |                                                          | Goes to the next route in history                                                                     |

--- a/examples/routing-with-resources/about.tsx
+++ b/examples/routing-with-resources/about.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link, createResource, useResource } from 'react-resource-router';
+import { homeRoute } from './routes';
 
 export const aboutResource = createResource({
   type: 'about',
@@ -22,7 +23,7 @@ export const About = () => {
   return (
     <div>
       <h1>About</h1>
-      <Link to={'/'}>Go to home</Link>
+      <Link to={homeRoute}>Go to home</Link>
       <section>
         <p>A picture of a schnauzer</p>
         <section>

--- a/examples/routing-with-resources/home.tsx
+++ b/examples/routing-with-resources/home.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link, createResource, useResource } from 'react-resource-router';
+import { aboutRoute } from './routes';
 
 export const homeResource = createResource({
   type: 'home',
@@ -20,7 +21,7 @@ export const Home = () => {
   return (
     <div>
       <h1>Home</h1>
-      <Link to={'/about'}>Go to about</Link>
+      <Link to={aboutRoute}>Go to about</Link>
       <section>
         <p>A random picture of a cute dog</p>
         <section>

--- a/examples/routing-with-resources/index.tsx
+++ b/examples/routing-with-resources/index.tsx
@@ -7,29 +7,11 @@ import {
   createBrowserHistory,
 } from 'react-resource-router';
 
-import { Home, homeResource } from './home';
-import { About, aboutResource } from './about';
+import { homeRoute, aboutRoute } from './routes';
 
 const myHistory = createBrowserHistory();
 
-const appRoutes = [
-  {
-    name: 'home',
-    path: '/',
-    exact: true,
-    component: Home,
-    navigation: null,
-    resources: [homeResource],
-  },
-  {
-    name: 'about',
-    path: '/about',
-    exact: true,
-    component: About,
-    navigation: null,
-    resources: [aboutResource],
-  },
-];
+const appRoutes = [homeRoute, aboutRoute];
 
 const App = () => {
   return (

--- a/examples/routing-with-resources/routes.tsx
+++ b/examples/routing-with-resources/routes.tsx
@@ -1,0 +1,20 @@
+import { Home, homeResource } from './home';
+import { About, aboutResource } from './about';
+
+export const homeRoute = {
+  name: 'home',
+  path: '/',
+  exact: true,
+  component: Home,
+  navigation: null,
+  resources: [homeResource],
+};
+
+export const aboutRoute = {
+  name: 'about',
+  path: '/about',
+  exact: true,
+  component: About,
+  navigation: null,
+  resources: [aboutResource],
+};

--- a/src/__tests__/unit/common/utils/match-route/test.ts
+++ b/src/__tests__/unit/common/utils/match-route/test.ts
@@ -1,12 +1,17 @@
 import { qs } from 'url-parse';
 
 import matchRoute from '../../../../../common/utils/match-route';
+import { matchRouteCache } from '../../../../../common/utils/match-route/utils';
 
 const Noop = () => null;
 const DEFAULT_QUERY_PARAMS = {};
 const { parse } = qs;
 
 describe('matchRoute', () => {
+  beforeEach(() => {
+    matchRouteCache.cache.clear();
+  });
+
   describe('pathname', () => {
     it('should match a pathname without a query string', () => {
       const route = { path: '/foo/:bar', component: Noop };
@@ -38,7 +43,7 @@ describe('matchRoute', () => {
 
       expect(
         // @ts-ignore
-        matchRoute([routeB], '/foo/abcd', DEFAULT_QUERY_PARAMS)
+        matchRoute([routeB], '/foo/abc', DEFAULT_QUERY_PARAMS)
       ).toMatchObject({
         route: routeB,
       });
@@ -117,7 +122,7 @@ describe('matchRoute', () => {
 
       expect(
         // @ts-ignore
-        matchRoute([routeB], '/base/foo/abcd', DEFAULT_QUERY_PARAMS, basePath)
+        matchRoute([routeB], '/base/foo/abc', DEFAULT_QUERY_PARAMS, basePath)
       ).toMatchObject({
         route: routeB,
       });

--- a/src/__tests__/unit/common/utils/match-route/test.ts
+++ b/src/__tests__/unit/common/utils/match-route/test.ts
@@ -38,7 +38,7 @@ describe('matchRoute', () => {
 
       expect(
         // @ts-ignore
-        matchRoute([routeB], '/foo/abc', DEFAULT_QUERY_PARAMS)
+        matchRoute([routeB], '/foo/abcd', DEFAULT_QUERY_PARAMS)
       ).toMatchObject({
         route: routeB,
       });
@@ -117,7 +117,7 @@ describe('matchRoute', () => {
 
       expect(
         // @ts-ignore
-        matchRoute([routeB], '/base/foo/abc', DEFAULT_QUERY_PARAMS, basePath)
+        matchRoute([routeB], '/base/foo/abcd', DEFAULT_QUERY_PARAMS, basePath)
       ).toMatchObject({
         route: routeB,
       });

--- a/src/__tests__/unit/controllers/router-store/test.tsx
+++ b/src/__tests__/unit/controllers/router-store/test.tsx
@@ -295,6 +295,32 @@ describe('SPA Router store', () => {
       });
     });
 
+    describe('pushTo', () => {
+      let children: any;
+
+      beforeEach(() => {
+        children = jest.fn().mockReturnValue(null);
+      });
+
+      it('should push a relative path generated from route and parameters', () => {
+        mount(
+          <MemoryRouter routes={[]}>
+            <RouterSubscriber>{children}</RouterSubscriber>
+          </MemoryRouter>
+        );
+        const route = { name: '', path: '/page/:id', component: () => null };
+        const { actions } = getRouterStore();
+
+        actions.pushTo(route, { params: { id: '1' }, query: { uid: '1' } });
+
+        expect(mockHistory.push).toBeCalledWith({
+          hash: '',
+          pathname: '/page/1',
+          search: '?uid=1',
+        });
+      });
+    });
+
     describe('replace', () => {
       let children: any;
 
@@ -335,6 +361,32 @@ describe('SPA Router store', () => {
 
         expect(window.location.href).toEqual(currentLocation);
         expect(window.location.replace).toBeCalledWith(path);
+      });
+    });
+
+    describe('replaceTo', () => {
+      let children: any;
+
+      beforeEach(() => {
+        children = jest.fn().mockReturnValue(null);
+      });
+
+      it('should replace a relative path generated from route and parameters', () => {
+        mount(
+          <MemoryRouter routes={[]}>
+            <RouterSubscriber>{children}</RouterSubscriber>
+          </MemoryRouter>
+        );
+        const route = { name: '', path: '/page/:id', component: () => null };
+        const { actions } = getRouterStore();
+
+        actions.replaceTo(route, { params: { id: '1' }, query: { uid: '1' } });
+
+        expect(mockHistory.replace).toBeCalledWith({
+          hash: '',
+          pathname: '/page/1',
+          search: '?uid=1',
+        });
       });
     });
   });

--- a/src/__tests__/unit/ui/link/test.tsx
+++ b/src/__tests__/unit/ui/link/test.tsx
@@ -40,11 +40,12 @@ const eventModifiers = [['metaKey'], ['altKey'], ['ctrlKey'], ['shiftKey']];
 describe('<Link />', () => {
   const mountInRouter = (
     children: LinkProps['children'],
-    props: Partial<LinkProps> = defaultProps
+    props: Partial<LinkProps> = defaultProps,
+    basePath = ''
   ) =>
     mount(
       // @ts-ignore
-      <Router history={HistoryMock} routes={[]}>
+      <Router history={HistoryMock} routes={[]} basePath={basePath}>
         <Link {...props}>{children}</Link>
       </Router>
     );
@@ -270,24 +271,32 @@ describe('<Link />', () => {
 
     it('should render with correct link', () => {
       // @ts-ignore
-      const wrapper = mountInRouter('my link', {
-        to: route,
-        params: { id: '1' },
-        query: { foo: 'bar' },
-      });
+      const wrapper = mountInRouter(
+        'my link',
+        {
+          to: route,
+          params: { id: '1' },
+          query: { foo: 'bar' },
+        },
+        '/base'
+      );
 
       expect(wrapper.html()).toEqual(
-        '<a href="/my-page/1?foo=bar" target="_self">my link</a>'
+        '<a href="/base/my-page/1?foo=bar" target="_self">my link</a>'
       );
     });
 
     it('should push history with correct link', () => {
       // @ts-ignore
-      const wrapper = mountInRouter('my link', {
-        to: route,
-        params: { id: '1' },
-        query: { foo: 'bar' },
-      });
+      const wrapper = mountInRouter(
+        'my link',
+        {
+          to: route,
+          params: { id: '1' },
+          query: { foo: 'bar' },
+        },
+        '/base'
+      );
       const component = wrapper.find('Link');
 
       component.simulate('click', baseClickEvent);
@@ -295,7 +304,7 @@ describe('<Link />', () => {
       expect(HistoryMock.push).toHaveBeenCalledTimes(1);
       expect(HistoryMock.push).toHaveBeenCalledWith({
         hash: '',
-        pathname: '/my-page/1',
+        pathname: '/base/my-page/1',
         search: '?foo=bar',
       });
     });

--- a/src/__tests__/unit/ui/link/test.tsx
+++ b/src/__tests__/unit/ui/link/test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import { mount } from 'enzyme';
-import { createPath } from 'history';
 import { defaultRegistry } from 'react-sweet-state';
 
 import { LinkProps } from '../../../../common/types';
@@ -187,27 +186,6 @@ describe('<Link />', () => {
       component.simulate('click', baseClickEvent);
 
       expect(HistoryMock.push).toHaveBeenCalledTimes(0);
-    });
-  });
-
-  describe('legacy support for Location objects', () => {
-    const location = {
-      search: '?foo=bar',
-      pathname: '/my-page',
-      hash: '#lol',
-    };
-
-    it('should navigate correctly when `href` is a location object', () => {
-      // @ts-ignore
-      const wrapper = mountInRouter('my link', { href: location });
-      const component = wrapper.find('Link');
-
-      component.simulate('click', baseClickEvent);
-      expect(wrapper.html()).toEqual(
-        '<a href="/my-page?foo=bar#lol" target="_self">my link</a>'
-      );
-      expect(HistoryMock.push).toHaveBeenCalledTimes(1);
-      expect(HistoryMock.push).toHaveBeenCalledWith(createPath(location));
     });
   });
 

--- a/src/__tests__/unit/ui/link/test.tsx
+++ b/src/__tests__/unit/ui/link/test.tsx
@@ -211,6 +211,78 @@ describe('<Link />', () => {
     });
   });
 
+  describe('when the link has `to` route prop defined', () => {
+    const route = {
+      name: 'my-page',
+      path: '/my-page/:id',
+      component: () => null,
+    };
+
+    it('should render the correct link', () => {
+      const wrapper = mountInRouter(
+        'my link',
+        {
+          to: route,
+          params: { id: '1' },
+          query: { foo: 'bar' },
+        },
+        '/base'
+      );
+
+      expect(wrapper.html()).toEqual(
+        '<a href="/base/my-page/1?foo=bar" target="_self">my link</a>'
+      );
+    });
+
+    it('should push history with correct link', () => {
+      const wrapper = mountInRouter(
+        'my link',
+        {
+          to: route,
+          params: { id: '1' },
+          query: { foo: 'bar' },
+        },
+        '/base'
+      );
+      const component = wrapper.find('Link');
+
+      component.simulate('click', baseClickEvent);
+
+      expect(HistoryMock.push).toHaveBeenCalledTimes(1);
+      expect(HistoryMock.push).toHaveBeenCalledWith({
+        hash: '',
+        pathname: '/base/my-page/1',
+        search: '?foo=bar',
+      });
+    });
+
+    it('should handle async route imports', async () => {
+      const wrapper = mountInRouter('my link', {
+        to: Promise.resolve({ default: route }),
+        params: { id: '1' },
+        query: { foo: 'bar' },
+      });
+      await Promise.resolve();
+      const component = wrapper.find('Link');
+
+      component.simulate('click', baseClickEvent);
+
+      expect(wrapper.html()).toEqual(
+        '<a href="/my-page/1?foo=bar" target="_self">my link</a>'
+      );
+      expect(HistoryMock.push).toHaveBeenCalledTimes(1);
+      expect(HistoryMock.push).toHaveBeenCalledWith({
+        hash: '',
+        pathname: '/my-page/1',
+        search: '?foo=bar',
+      });
+    });
+
+    it('should error if required route parameters are missing', () => {
+      expect(() => mountInRouter('my link', { to: route })).toThrow();
+    });
+  });
+
   describe('when the link has focus, and a keypress is fired', () => {
     it('should navigate if the key was an `enter`', () => {
       const wrapper = mountInRouter('my link', { href: newPath });
@@ -259,89 +331,6 @@ describe('<Link />', () => {
       });
       const anchor = wrapper.find('a');
       expect(anchor.props()).toMatchObject({ style: { color: 'yellow' } });
-    });
-  });
-
-  describe('when the link has to route prop defined', () => {
-    const route = {
-      name: 'my-page',
-      path: '/my-page/:id',
-      component: () => null,
-    };
-
-    it('should render with correct link', () => {
-      // @ts-ignore
-      const wrapper = mountInRouter(
-        'my link',
-        {
-          to: route,
-          params: { id: '1' },
-          query: { foo: 'bar' },
-        },
-        '/base'
-      );
-
-      expect(wrapper.html()).toEqual(
-        '<a href="/base/my-page/1?foo=bar" target="_self">my link</a>'
-      );
-    });
-
-    it('should push history with correct link', () => {
-      // @ts-ignore
-      const wrapper = mountInRouter(
-        'my link',
-        {
-          to: route,
-          params: { id: '1' },
-          query: { foo: 'bar' },
-        },
-        '/base'
-      );
-      const component = wrapper.find('Link');
-
-      component.simulate('click', baseClickEvent);
-
-      expect(HistoryMock.push).toHaveBeenCalledTimes(1);
-      expect(HistoryMock.push).toHaveBeenCalledWith({
-        hash: '',
-        pathname: '/base/my-page/1',
-        search: '?foo=bar',
-      });
-    });
-
-    it('should handle async route imports', async () => {
-      // @ts-ignore
-      const wrapper = mountInRouter('my link', {
-        to: Promise.resolve({ default: route }),
-        params: { id: '1' },
-        query: { foo: 'bar' },
-      });
-      await Promise.resolve();
-      const component = wrapper.find('Link');
-
-      component.simulate('click', baseClickEvent);
-
-      expect(wrapper.html()).toEqual(
-        '<a href="/my-page/1?foo=bar" target="_self">my link</a>'
-      );
-      expect(HistoryMock.push).toHaveBeenCalledTimes(1);
-      expect(HistoryMock.push).toHaveBeenCalledWith({
-        hash: '',
-        pathname: '/my-page/1',
-        search: '?foo=bar',
-      });
-    });
-
-    it('should error if required route parameters are missing', () => {
-      let error;
-      try {
-        // @ts-ignore
-        mountInRouter('my link', { to: route });
-      } catch (err) {
-        error = err;
-      }
-
-      expect(error).toBeInstanceOf(Error);
     });
   });
 });

--- a/src/__tests__/unit/ui/link/test.tsx
+++ b/src/__tests__/unit/ui/link/test.tsx
@@ -202,18 +202,9 @@ describe('<Link />', () => {
       const component = wrapper.find('Link');
 
       component.simulate('click', baseClickEvent);
-
-      expect(HistoryMock.push).toHaveBeenCalledTimes(1);
-      expect(HistoryMock.push).toHaveBeenCalledWith(createPath(location));
-    });
-
-    it('should navigate correctly when `to` is a location object', () => {
-      // @ts-ignore
-      const wrapper = mountInRouter('my link', { to: location });
-      const component = wrapper.find('Link');
-
-      component.simulate('click', baseClickEvent);
-
+      expect(wrapper.html()).toEqual(
+        '<a href="/my-page?foo=bar#lol" target="_self">my link</a>'
+      );
       expect(HistoryMock.push).toHaveBeenCalledTimes(1);
       expect(HistoryMock.push).toHaveBeenCalledWith(createPath(location));
     });
@@ -267,6 +258,81 @@ describe('<Link />', () => {
       });
       const anchor = wrapper.find('a');
       expect(anchor.props()).toMatchObject({ style: { color: 'yellow' } });
+    });
+  });
+
+  describe('when the link has to route prop defined', () => {
+    const route = {
+      name: 'my-page',
+      path: '/my-page/:id',
+      component: () => null,
+    };
+
+    it('should render with correct link', () => {
+      // @ts-ignore
+      const wrapper = mountInRouter('my link', {
+        to: route,
+        params: { id: '1' },
+        query: { foo: 'bar' },
+      });
+
+      expect(wrapper.html()).toEqual(
+        '<a href="/my-page/1?foo=bar" target="_self">my link</a>'
+      );
+    });
+
+    it('should push history with correct link', () => {
+      // @ts-ignore
+      const wrapper = mountInRouter('my link', {
+        to: route,
+        params: { id: '1' },
+        query: { foo: 'bar' },
+      });
+      const component = wrapper.find('Link');
+
+      component.simulate('click', baseClickEvent);
+
+      expect(HistoryMock.push).toHaveBeenCalledTimes(1);
+      expect(HistoryMock.push).toHaveBeenCalledWith({
+        hash: '',
+        pathname: '/my-page/1',
+        search: '?foo=bar',
+      });
+    });
+
+    it('should handle async route imports', async () => {
+      // @ts-ignore
+      const wrapper = mountInRouter('my link', {
+        to: Promise.resolve({ default: route }),
+        params: { id: '1' },
+        query: { foo: 'bar' },
+      });
+      await Promise.resolve();
+      const component = wrapper.find('Link');
+
+      component.simulate('click', baseClickEvent);
+
+      expect(wrapper.html()).toEqual(
+        '<a href="/my-page/1?foo=bar" target="_self">my link</a>'
+      );
+      expect(HistoryMock.push).toHaveBeenCalledTimes(1);
+      expect(HistoryMock.push).toHaveBeenCalledWith({
+        hash: '',
+        pathname: '/my-page/1',
+        search: '?foo=bar',
+      });
+    });
+
+    it('should error if required route parameters are missing', () => {
+      let error;
+      try {
+        // @ts-ignore
+        mountInRouter('my link', { to: route });
+      } catch (err) {
+        error = err;
+      }
+
+      expect(error).toBeInstanceOf(Error);
     });
   });
 });

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -122,7 +122,7 @@ export type RouteResource<RouteResourceData = unknown> = {
 
 export type RouteResources = RouteResource[];
 
-export type ResourceStoreContext = Record<string, any>;
+export type ResourceStoreContext = any;
 
 export type RouteResourceDataForType = {
   [index: string]: RouteResourceResponseBase<unknown>;
@@ -229,10 +229,12 @@ export type LinkProps = {
   children: ReactNode;
   target?: '_blank' | '_self' | '_parent' | '_top';
   href?: string;
-  to?: string;
+  to?: string | Route | Promise<{ default: Route }>;
   replace?: boolean;
   type?: 'a' | 'button';
   onClick?: (e: any) => void;
+  params?: MatchParams;
+  query?: Query;
 };
 
 export type HistoryBlocker = (
@@ -271,6 +273,12 @@ export type MemoryRouterProps = {
   children: ReactNode;
   resourceData?: ResourceStoreData;
   resourceContext?: ResourceStoreContext;
+};
+
+export type GenerateLocationOptions = {
+  params?: MatchParams;
+  query?: Query;
+  basePath?: string;
 };
 
 export type CreateRouterContextOptions = {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -229,7 +229,7 @@ export type LinkProps = {
   children: ReactNode;
   target?: '_blank' | '_self' | '_parent' | '_top';
   href?: string;
-  to?: string | Route | Promise<{ default: Route }>;
+  to?: string | Route | Promise<{ default: Route } | Route>;
   replace?: boolean;
   type?: 'a' | 'button';
   onClick?: (e: any) => void;

--- a/src/common/utils/generate-location/index.ts
+++ b/src/common/utils/generate-location/index.ts
@@ -1,0 +1,21 @@
+import pathToRegexp from 'path-to-regexp';
+import { qs } from 'url-parse';
+
+import { GenerateLocationOptions, Location } from '../../types';
+
+export function generateLocationFromPath(
+  pattern = '/',
+  options: GenerateLocationOptions = {}
+): Location {
+  const { params = {}, query = {}, basePath = '' } = options;
+  // @ts-ignore stringify accepts two params but it's type doesn't say so
+  const stringifiedQuery = qs.stringify(query, true);
+  const pathname =
+    pattern === '/' ? pattern : pathToRegexp.compile(pattern)(params);
+
+  return {
+    pathname: `${basePath}${pathname}`,
+    search: stringifiedQuery,
+    hash: '',
+  };
+}

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -1,4 +1,8 @@
-export { default as matchRoute, matchInvariantRoute } from './match-route';
+export {
+  default as matchRoute,
+  matchInvariantRoute,
+  warmupMatchRouteCache,
+} from './match-route';
 export { default as generatePath } from './generate-path';
 export { generateLocationFromPath } from './generate-location';
 export { createLegacyHistory } from './history';

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -1,5 +1,6 @@
 export { default as matchRoute, matchInvariantRoute } from './match-route';
 export { default as generatePath } from './generate-path';
+export { generateLocationFromPath } from './generate-location';
 export { createLegacyHistory } from './history';
 export { isServerEnvironment } from './is-server-environment';
 export { findRouterContext, createRouterContext } from './router-context';

--- a/src/common/utils/match-route/exec-route-matching.ts
+++ b/src/common/utils/match-route/exec-route-matching.ts
@@ -1,0 +1,43 @@
+import { Query, Route, InvariantRoute, Match } from '../../types';
+
+import matchPath from './matchPath';
+import matchQuery from './matchQuery';
+
+/* This should match what react-router does to compute a root match. */
+const computeRootMatch = (pathname: string) => ({
+  path: '/',
+  url: '/',
+  params: {},
+  isExact: pathname === '/',
+  query: {},
+});
+
+function execRouteMatching<T extends Route | InvariantRoute>(
+  route: T,
+  pathname: string,
+  queryObj: Query,
+  basePath: string
+): { route: T; match: Match } | null {
+  const pathMatch = route.path
+    ? matchPath(pathname, {
+        path: route.path,
+        exact: route.exact,
+        basePath,
+      })
+    : computeRootMatch(pathname);
+  let match = pathMatch;
+
+  if (pathMatch && route.query) {
+    match = matchQuery(route.query, queryObj, pathMatch);
+  } else if (pathMatch) {
+    match = { ...pathMatch, query: {} };
+  }
+
+  if (match) {
+    return { match, route };
+  }
+
+  return null;
+}
+
+export default execRouteMatching;

--- a/src/common/utils/match-route/index.ts
+++ b/src/common/utils/match-route/index.ts
@@ -57,7 +57,7 @@ const matchRoute = <T extends Route | InvariantRoute>(
 export const matchInvariantRoute = (
   routes: InvariantRoutes,
   pathname: string,
-  queryParams: Query,
+  queryParams: Query | undefined,
   basePath = ''
 ): MatchedInvariantRoute | null =>
   matchRoute(routes, pathname, queryParams, basePath);
@@ -65,6 +65,6 @@ export const matchInvariantRoute = (
 export default (
   routes: Routes,
   pathname: string,
-  queryParams: Query,
+  queryParams: Query | undefined,
   basePath = ''
 ): MatchedRoute | null => matchRoute(routes, pathname, queryParams, basePath);

--- a/src/common/utils/match-route/index.ts
+++ b/src/common/utils/match-route/index.ts
@@ -1,91 +1,16 @@
 import { qs } from 'url-parse';
 
 import {
-  Match,
   InvariantRoutes,
   MatchedRoute,
-  MatchParams,
   MatchedInvariantRoute,
   Query,
   Routes,
+  Route,
+  InvariantRoute,
 } from '../../types';
-
-import matchPath from './matchPath';
-
-/* This should match what react-router does to compute a root match. */
-const computeRootMatch = (pathname: string) => ({
-  path: '/',
-  url: '/',
-  params: {},
-  isExact: pathname === '/',
-  query: {},
-});
-
-/**
- * Matches `queryStr` against config stored in `queryConfig`.
- *
- * Returns `pathMatch` with an additional query prop with query params if the match succeeds,
- * otherwise returns null.
- *
- * TODO we are using `ReactRouterMatch` here until we migrate `matchPath` to be our own module.
- */
-const matchQuery = (
-  queryConfig: string[],
-  queryParams: MatchParams,
-  pathMatch: Match
-): Match | null => {
-  const queryMatch: Query = {};
-  const isMatchingQuery = queryConfig.every(query => {
-    // eslint-disable-next-line prefer-const
-    let [names, value] = query.split('=');
-    let negation = false;
-
-    /* Check if negative matching query param (eg 'foo!=1') */
-    if (query.includes('!=')) {
-      names = names.substring(0, names.length - 1);
-      negation = true;
-    }
-
-    /* Allow alternate query params presence (eg 'foo|bar') */
-    const matched = names.split('|').map(name => {
-      let isOptional = false;
-
-      /* Check if optional query param (eg 'foo?') */
-      if (name.includes('?')) {
-        // eslint-disable-next-line no-param-reassign
-        name = name.substring(0, name.length - 1);
-        isOptional = true;
-      }
-
-      /* First check if queryParams contains the relevant param */
-      let match = Object.prototype.hasOwnProperty.call(queryParams, name);
-      /* Save actual value so we expose it as part of match object */
-      if (match) {
-        queryMatch[name] = queryParams[name] || '';
-      }
-
-      /* If no value matching required or it is optional and the param is missing */
-      if (!value || (isOptional && !match)) {
-        return isOptional || match;
-      }
-
-      if (value.startsWith('(')) {
-        /* Handle value being a regexp eg 's=(\\d+)' */
-        match = new RegExp(`^${value}$`).test(queryParams[name] || '');
-      } else {
-        /* Handle value exact matching eg 's=123' */
-        match = queryParams[name] === value;
-      }
-
-      return negation ? !match : match;
-    });
-
-    /* If at least one of alternate query params matches then it is a match */
-    return matched.includes(true);
-  });
-
-  return isMatchingQuery ? { ...pathMatch, query: queryMatch } : null;
-};
+import execRouteMatching from './exec-route-matching';
+import { matchRouteCache } from './utils';
 
 /**
  * Does the given `pathname` and `queryStr` match a route in `routes`.
@@ -94,48 +19,45 @@ const matchQuery = (
  *
  * Note: This does not support nested routes at this stage.
  */
-const matchRoute = <T extends Routes | InvariantRoutes>(
-  routes: T,
+const matchRoute = <T extends Route | InvariantRoute>(
+  routes: T[],
   pathname: string,
-  queryParams: MatchParams,
+  queryParams: Query = {},
   basePath = ''
-): (T extends Routes ? MatchedRoute : MatchedInvariantRoute) | null => {
+) => {
   const queryParamObject =
     typeof queryParams === 'string'
       ? (qs.parse(queryParams) as Query)
       : queryParams;
-  let matchedRoute = null;
 
-  routes.some(route => {
-    const pathMatch = route.path
-      ? matchPath(pathname, {
-          path: route.path,
-          exact: route.exact,
-          basePath,
-        })
-      : computeRootMatch(pathname);
-    let match = pathMatch;
+  const cachedMatch = matchRouteCache.get<T>(
+    pathname,
+    queryParamObject,
+    basePath
+  );
+  if (cachedMatch && routes.includes(cachedMatch.route)) return cachedMatch;
 
-    if (pathMatch && route.query) {
-      match = matchQuery(route.query, queryParamObject, pathMatch);
-    } else if (pathMatch) {
-      match = { ...pathMatch, query: {} };
+  for (let i = 0; i < routes.length; i++) {
+    const matchedRoute = execRouteMatching(
+      routes[i],
+      pathname,
+      queryParamObject,
+      basePath
+    );
+    if (matchedRoute) {
+      matchRouteCache.set(pathname, queryParamObject, basePath, matchedRoute);
+
+      return matchedRoute;
     }
+  }
 
-    if (match) {
-      matchedRoute = { match, route };
-    }
-
-    return match;
-  });
-
-  return matchedRoute;
+  return null;
 };
 
 export const matchInvariantRoute = (
   routes: InvariantRoutes,
   pathname: string,
-  queryParams: MatchParams,
+  queryParams: Query,
   basePath = ''
 ): MatchedInvariantRoute | null =>
   matchRoute(routes, pathname, queryParams, basePath);
@@ -143,6 +65,6 @@ export const matchInvariantRoute = (
 export default (
   routes: Routes,
   pathname: string,
-  queryParams: MatchParams,
+  queryParams: Query,
   basePath = ''
 ): MatchedRoute | null => matchRoute(routes, pathname, queryParams, basePath);

--- a/src/common/utils/match-route/index.ts
+++ b/src/common/utils/match-route/index.ts
@@ -62,6 +62,19 @@ export const matchInvariantRoute = (
 ): MatchedInvariantRoute | null =>
   matchRoute(routes, pathname, queryParams, basePath);
 
+/**
+ * Performance optimisation to fast-match a single route
+ * instead of looping thorugh all defined routes
+ */
+export const warmupMatchRouteCache = (
+  route: Route,
+  pathname: string,
+  queryParams: Query | undefined,
+  basePath = ''
+) => {
+  matchRoute([route], pathname, queryParams, basePath);
+};
+
 export default (
   routes: Routes,
   pathname: string,

--- a/src/common/utils/match-route/matchQuery.ts
+++ b/src/common/utils/match-route/matchQuery.ts
@@ -1,0 +1,68 @@
+import { Match, MatchParams, Query } from '../../types';
+
+/**
+ * Matches `queryStr` against config stored in `queryConfig`.
+ *
+ * Returns `pathMatch` with an additional query prop with query params if the match succeeds,
+ * otherwise returns null.
+ *
+ */
+function matchQuery(
+  queryConfig: string[],
+  queryParams: MatchParams,
+  pathMatch: Match
+): Match | null {
+  const queryMatch: Query = {};
+  const isMatchingQuery = queryConfig.every(query => {
+    // eslint-disable-next-line prefer-const
+    let [names, value] = query.split('=');
+    let negation = false;
+
+    /* Check if negative matching query param (eg 'foo!=1') */
+    if (query.includes('!=')) {
+      names = names.substring(0, names.length - 1);
+      negation = true;
+    }
+
+    /* Allow alternate query params presence (eg 'foo|bar') */
+    const matched = names.split('|').map(name => {
+      let isOptional = false;
+
+      /* Check if optional query param (eg 'foo?') */
+      if (name.includes('?')) {
+        // eslint-disable-next-line no-param-reassign
+        name = name.substring(0, name.length - 1);
+        isOptional = true;
+      }
+
+      /* First check if queryParams contains the relevant param */
+      let match = Object.prototype.hasOwnProperty.call(queryParams, name);
+      /* Save actual value so we expose it as part of match object */
+      if (match) {
+        queryMatch[name] = queryParams[name] || '';
+      }
+
+      /* If no value matching required or it is optional and the param is missing */
+      if (!value || (isOptional && !match)) {
+        return isOptional || match;
+      }
+
+      if (value.startsWith('(')) {
+        /* Handle value being a regexp eg 's=(\\d+)' */
+        match = new RegExp(`^${value}$`).test(queryParams[name] || '');
+      } else {
+        /* Handle value exact matching eg 's=123' */
+        match = queryParams[name] === value;
+      }
+
+      return negation ? !match : match;
+    });
+
+    /* If at least one of alternate query params matches then it is a match */
+    return matched.includes(true);
+  });
+
+  return isMatchingQuery ? { ...pathMatch, query: queryMatch } : null;
+}
+
+export default matchQuery;

--- a/src/common/utils/match-route/utils.ts
+++ b/src/common/utils/match-route/utils.ts
@@ -1,0 +1,66 @@
+import { Match, Query } from '../../../common/types';
+
+const hasOwnProperty = Object.prototype.hasOwnProperty;
+
+function shallowEqual(objA: any, objB: any) {
+  if (objA === objB) {
+    return true;
+  }
+
+  if (
+    typeof objA !== 'object' ||
+    objA === null ||
+    typeof objB !== 'object' ||
+    objB === null
+  ) {
+    return false;
+  }
+
+  const keysA = Object.keys(objA);
+  const keysB = Object.keys(objB);
+
+  if (keysA.length !== keysB.length) {
+    return false;
+  }
+
+  // Test for A's keys different from B.
+  for (let i = 0; i < keysA.length; i++) {
+    if (
+      !hasOwnProperty.call(objB, keysA[i]) ||
+      objA[keysA[i]] !== objB[keysA[i]]
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export const matchRouteCache = {
+  cache: new Map(),
+  get<T>(
+    pathname: string,
+    queryObj: Query,
+    basePath: string
+  ): { route: T; match: Match } | void {
+    const pathCache = this.cache.get(basePath + pathname);
+    if (pathCache) {
+      for (const [key, value] of pathCache) {
+        if (shallowEqual(key, queryObj)) return value;
+      }
+    }
+  },
+  set<T>(
+    pathname: string,
+    queryObj: Query,
+    basePath: string,
+    matchRoute: { route: T; match: Match }
+  ): void {
+    const pathCache = this.cache.get(basePath + pathname);
+    if (pathCache) {
+      pathCache.set(queryObj, matchRoute);
+    } else {
+      this.cache.set(basePath + pathname, new Map([[queryObj, matchRoute]]));
+    }
+  },
+};

--- a/src/common/utils/match-route/utils.ts
+++ b/src/common/utils/match-route/utils.ts
@@ -1,6 +1,7 @@
 import { Match, Query } from '../../../common/types';
 
 const hasOwnProperty = Object.prototype.hasOwnProperty;
+const MAX_CACHE_SIZE = 1000;
 
 function shallowEqual(objA: any, objB: any) {
   if (objA === objB) {
@@ -37,7 +38,7 @@ function shallowEqual(objA: any, objB: any) {
 }
 
 export const matchRouteCache = {
-  cache: new Map(),
+  cache: new Map<string, Map<Query, { route: any; match: Match }>>(),
   get<T>(
     pathname: string,
     queryObj: Query,
@@ -56,8 +57,10 @@ export const matchRouteCache = {
     basePath: string,
     matchRoute: { route: T; match: Match }
   ): void {
+    if (this.cache.size > MAX_CACHE_SIZE) this.cache.clear();
     const pathCache = this.cache.get(basePath + pathname);
     if (pathCache) {
+      if (pathCache.size > MAX_CACHE_SIZE / 10) pathCache.clear();
       pathCache.set(queryObj, matchRoute);
     } else {
       this.cache.set(basePath + pathname, new Map([[queryObj, matchRoute]]));

--- a/src/controllers/router-store/index.tsx
+++ b/src/controllers/router-store/index.tsx
@@ -17,6 +17,8 @@ import {
   findRouterContext,
   isServerEnvironment,
   generatePath as generatePathUsingPathParams,
+  generateLocationFromPath,
+  matchRoute,
 } from '../../common/utils';
 import { getResourceStore } from '../resource-store';
 import { getResourcesForNextLocation } from '../resource-store/utils';
@@ -62,13 +64,14 @@ const actions: AllRouterActions = {
       resourceData,
       basePath = '',
       routes,
+      initialRoute,
       ...initialProps
     } = props;
     const { history, isStatic } = initialProps;
-    const routerContext = findRouterContext(routes, {
-      location: history.location,
-      basePath,
-    });
+    const routerContext = findRouterContext(
+      initialRoute ? [initialRoute] : routes,
+      { location: history.location, basePath }
+    );
 
     setState({
       ...initialProps,
@@ -137,11 +140,12 @@ const actions: AllRouterActions = {
    *
    */
   listen: () => ({ getState, setState }) => {
-    const { history, routes, basePath } = getState();
+    const { history } = getState();
 
-    const stopListening = history.listen(async (location, action) => {
-      const nextContext = findRouterContext(routes, { location, basePath });
+    const stopListening = history.listen((location, action) => {
       const {
+        routes,
+        basePath,
         match: currentMatch,
         route: currentRoute,
         query: currentQuery,
@@ -154,6 +158,8 @@ const actions: AllRouterActions = {
           getContext: getResourceStoreContext,
         },
       } = getResourceStore();
+
+      const nextContext = findRouterContext(routes, { location, basePath });
       const nextLocationContext = {
         route: nextContext.route,
         match: nextContext.match,
@@ -199,14 +205,45 @@ const actions: AllRouterActions = {
     }
   },
 
+  pushTo: (route, attributes) => ({ getState }) => {
+    const { history, basePath } = getState();
+    const location = generateLocationFromPath(route.path, {
+      ...attributes,
+      basePath,
+    });
+    const newMatch = matchRoute(
+      [route],
+      location.pathname,
+      attributes.query,
+      basePath
+    );
+    if (!newMatch) throw new Error('Provided route does not match');
+    history.push(location as any);
+  },
+
   replace: path => ({ getState }) => {
     const { history, basePath } = getState();
-
     if (isExternalAbsolutePath(path)) {
       window.location.replace(path as string);
     } else {
       history.replace(getRelativePath(path, basePath) as any);
     }
+  },
+
+  replaceTo: (route, attributes) => ({ getState }) => {
+    const { history, basePath } = getState();
+    const location = generateLocationFromPath(route.path, {
+      ...attributes,
+      basePath,
+    });
+    const newMatch = matchRoute(
+      [route],
+      location.pathname,
+      attributes.query,
+      basePath
+    );
+    if (!newMatch) throw new Error('Provided route does not match');
+    history.replace(location as any);
   },
 
   goBack: () => ({ getState }) => {

--- a/src/controllers/router-store/index.tsx
+++ b/src/controllers/router-store/index.tsx
@@ -18,7 +18,7 @@ import {
   isServerEnvironment,
   generatePath as generatePathUsingPathParams,
   generateLocationFromPath,
-  matchRoute,
+  warmupMatchRouteCache,
 } from '../../common/utils';
 import { getResourceStore } from '../resource-store';
 import { getResourcesForNextLocation } from '../resource-store/utils';
@@ -211,13 +211,7 @@ const actions: AllRouterActions = {
       ...attributes,
       basePath,
     });
-    const newMatch = matchRoute(
-      [route],
-      location.pathname,
-      attributes.query,
-      basePath
-    );
-    if (!newMatch) throw new Error('Provided route does not match');
+    warmupMatchRouteCache(route, location.pathname, attributes.query, basePath);
     history.push(location as any);
   },
 
@@ -236,13 +230,7 @@ const actions: AllRouterActions = {
       ...attributes,
       basePath,
     });
-    const newMatch = matchRoute(
-      [route],
-      location.pathname,
-      attributes.query,
-      basePath
-    );
-    if (!newMatch) throw new Error('Provided route does not match');
+    warmupMatchRouteCache(route, location.pathname, attributes.query, basePath);
     history.replace(location as any);
   },
 

--- a/src/controllers/router-store/index.tsx
+++ b/src/controllers/router-store/index.tsx
@@ -205,7 +205,7 @@ const actions: AllRouterActions = {
     }
   },
 
-  pushTo: (route, attributes) => ({ getState }) => {
+  pushTo: (route, attributes = {}) => ({ getState }) => {
     const { history, basePath } = getState();
     const location = generateLocationFromPath(route.path, {
       ...attributes,
@@ -230,7 +230,7 @@ const actions: AllRouterActions = {
     }
   },
 
-  replaceTo: (route, attributes) => ({ getState }) => {
+  replaceTo: (route, attributes = {}) => ({ getState }) => {
     const { history, basePath } = getState();
     const location = generateLocationFromPath(route.path, {
       ...attributes,
@@ -268,6 +268,12 @@ const actions: AllRouterActions = {
     const { query, route, match } = getState();
 
     return { query, route, match };
+  },
+
+  getBasePath: () => ({ getState }) => {
+    const { basePath } = getState();
+
+    return basePath;
   },
 
   updateQueryParam: (params, updateType = 'push') => ({ getState }) => {

--- a/src/controllers/router-store/types.ts
+++ b/src/controllers/router-store/types.ts
@@ -87,9 +87,9 @@ type PrivateRouterActions = {
 };
 
 type PublicRouterActions = {
-  push: (path: Href | Location, state?: any) => RouterAction;
+  push: (path: Href, state?: any) => RouterAction;
   pushTo: (route: Route, attributes?: ToAttributes) => RouterAction;
-  replace: (path: Href | Location) => RouterAction;
+  replace: (path: Href) => RouterAction;
   replaceTo: (route: Route, attributes?: ToAttributes) => RouterAction;
   goBack: () => RouterAction;
   goForward: () => RouterAction;

--- a/src/controllers/router-store/types.ts
+++ b/src/controllers/router-store/types.ts
@@ -41,6 +41,7 @@ export type EntireRouterState = PublicStateProperties & PrivateStateProperties;
 export type ContainerProps = {
   isStatic?: boolean;
   history: BrowserHistory | MemoryHistory;
+  initialRoute?: Route;
   location?: Location;
   basePath?: string;
   routes: Routes;
@@ -81,7 +82,9 @@ type PrivateRouterActions = {
 
 type PublicRouterActions = {
   push: (path: Href | Location, state?: any) => RouterAction;
+  pushTo: (route: Route, attributes?: any) => RouterAction;
   replace: (path: Href | Location) => RouterAction;
+  replaceTo: (route: Route, attributes?: any) => RouterAction;
   goBack: () => RouterAction;
   goForward: () => RouterAction;
   registerBlock: (blocker: HistoryBlocker | any) => RouterAction;

--- a/src/controllers/router-store/types.ts
+++ b/src/controllers/router-store/types.ts
@@ -9,6 +9,7 @@ import {
   Href,
   Location,
   Match,
+  MatchParams,
   Query,
   ResourceStoreContext,
   ResourceStoreData,
@@ -58,6 +59,11 @@ export type RouterAction = Action<EntireRouterState, AllRouterActions>;
 
 export type HistoryUpdateType = 'push' | 'replace';
 
+type ToAttributes = {
+  params?: MatchParams;
+  query?: Query;
+};
+
 type PrivateRouterActions = {
   bootstrapStore: (initialState: ContainerProps) => RouterAction;
   bootstrapStoreUniversal: (
@@ -82,12 +88,13 @@ type PrivateRouterActions = {
 
 type PublicRouterActions = {
   push: (path: Href | Location, state?: any) => RouterAction;
-  pushTo: (route: Route, attributes?: any) => RouterAction;
+  pushTo: (route: Route, attributes?: ToAttributes) => RouterAction;
   replace: (path: Href | Location) => RouterAction;
-  replaceTo: (route: Route, attributes?: any) => RouterAction;
+  replaceTo: (route: Route, attributes?: ToAttributes) => RouterAction;
   goBack: () => RouterAction;
   goForward: () => RouterAction;
   registerBlock: (blocker: HistoryBlocker | any) => RouterAction;
+  getBasePath: () => RouterAction;
 };
 
 export type AllRouterActions = PrivateRouterActions & PublicRouterActions;

--- a/src/controllers/router/index.tsx
+++ b/src/controllers/router/index.tsx
@@ -48,6 +48,7 @@ export class Router extends Component<RouterProps> {
       children,
       routes,
       history,
+      initialRoute,
       isStatic,
       basePath,
       resourceContext,
@@ -59,6 +60,7 @@ export class Router extends Component<RouterProps> {
         basePath={basePath}
         routes={routes}
         history={history}
+        initialRoute={initialRoute}
         isStatic={isStatic}
         resourceContext={resourceContext}
         resourceData={resourceData}

--- a/src/controllers/router/types.ts
+++ b/src/controllers/router/types.ts
@@ -4,12 +4,14 @@ import {
   BrowserHistory,
   ResourceStoreContext,
   ResourceStoreData,
+  Route,
   Routes,
 } from '../../common/types';
 
 export type RouterProps = {
   isStatic: boolean;
   history: BrowserHistory;
+  initialRoute?: Route;
   resourceContext?: ResourceStoreContext;
   resourceData?: ResourceStoreData;
   basePath?: string;

--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -175,12 +175,20 @@ type PrivateRouterActions = {|
 
 type Href = string;
 
+type ToAttributes = {
+  params?: MatchParams,
+  query?: Query,
+};
+
 export type RouterActionsType = {|
   push: (path: Href | LocationShape, state?: any) => RouterAction,
+  pushTo: (route: Route, attributes: ToAttributes) => RouterAction,
   replace: (path: Href | LocationShape, state?: any) => RouterAction,
+  replaceTo: (route: Route, attributes: ToAttributes) => RouterAction,
   goBack: () => RouterAction,
   goForward: () => RouterAction,
   registerBlock: (blocker: HistoryBlocker | any) => RouterAction,
+  getBasePath: () => RouterAction,
 |};
 
 type AllRouterActions = {|

--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -300,10 +300,12 @@ export type LinkProps = {|
   children: Node,
   target?: '_blank' | '_self' | '_parent' | '_top',
   href?: string,
-  to?: string,
+  to?: string | Route | Promise<{ default: Route, ... }> | Promise<Route>,
   replace?: boolean,
   type?: 'a' | 'button',
   onClick?: (e: any) => void,
+  params?: MatchParams,
+  query?: Query,
 |};
 
 export type RouterSubscriberProps = {|

--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -181,9 +181,9 @@ type ToAttributes = {
 };
 
 export type RouterActionsType = {|
-  push: (path: Href | LocationShape, state?: any) => RouterAction,
+  push: (path: Href, state?: any) => RouterAction,
   pushTo: (route: Route, attributes: ToAttributes) => RouterAction,
-  replace: (path: Href | LocationShape, state?: any) => RouterAction,
+  replace: (path: Href, state?: any) => RouterAction,
   replaceTo: (route: Route, attributes: ToAttributes) => RouterAction,
   goBack: () => RouterAction,
   goForward: () => RouterAction,

--- a/src/ui/link/index.tsx
+++ b/src/ui/link/index.tsx
@@ -1,9 +1,9 @@
-import React, { createElement, forwardRef } from 'react';
-
 import { createPath } from 'history';
+import { createElement, forwardRef, useState } from 'react';
 
-import { LinkProps } from '../../common/types';
-import { RouterActions } from '../../controllers';
+import { LinkProps, Route } from '../../common/types';
+import { generateLocationFromPath } from '../../common/utils';
+import { useRouterActions } from '../../controllers';
 
 import { getValidLinkType, handleNavigation } from './utils';
 
@@ -13,49 +13,57 @@ const Link = forwardRef<HTMLButtonElement | HTMLAnchorElement, LinkProps>(
       children,
       target = '_self',
       replace = false,
-      href = '',
-      to = '',
+      href = undefined,
+      to = undefined,
       onClick = undefined,
       type: linkType = 'a',
+      params,
+      query,
       ...rest
     },
     ref
   ) => {
-    return (
-      <RouterActions>
-        {({ push, replace: replaceAction }) => {
-          const validLinkType = getValidLinkType(linkType);
-          const linkTargetProp = href || to || '';
-          const linkDestination =
-            typeof linkTargetProp === 'object'
-              ? createPath(linkTargetProp)
-              : linkTargetProp;
+    const routerActions = useRouterActions();
+    const validLinkType = getValidLinkType(linkType);
+    const [route, setRoute] = useState<Route | void>(() => {
+      if (to && typeof to !== 'string') {
+        if ('then' in to) to.then(r => setRoute(r.default));
+        else return to;
+      }
+    });
 
-          const routerActions = { push, replace: replaceAction };
+    const routeAttributes = { params, query, basePath: '' };
+    const linkDestination = href
+      ? typeof href !== 'string'
+        ? createPath(href)
+        : href
+      : typeof to !== 'string'
+      ? (route &&
+          createPath(generateLocationFromPath(route.path, routeAttributes))) ||
+        ''
+      : to;
 
-          const handleLinkPress = (e: any) =>
-            handleNavigation(e, {
-              onClick,
-              target,
-              replace,
-              routerActions,
-              href: linkDestination,
-            });
+    const handleLinkPress = (e: any) =>
+      handleNavigation(e, {
+        onClick,
+        target,
+        replace,
+        routerActions,
+        href: linkDestination,
+        to: route && [route, { params, query }],
+      });
 
-          return createElement(
-            validLinkType,
-            {
-              ...rest,
-              href: linkDestination,
-              target,
-              onClick: handleLinkPress,
-              onKeyDown: handleLinkPress,
-              ref,
-            },
-            children
-          );
-        }}
-      </RouterActions>
+    return createElement(
+      validLinkType,
+      {
+        ...rest,
+        href: linkDestination,
+        target,
+        onClick: handleLinkPress,
+        onKeyDown: handleLinkPress,
+        ref,
+      },
+      children
     );
   }
 );

--- a/src/ui/link/index.tsx
+++ b/src/ui/link/index.tsx
@@ -27,7 +27,8 @@ const Link = forwardRef<HTMLButtonElement | HTMLAnchorElement, LinkProps>(
     const validLinkType = getValidLinkType(linkType);
     const [route, setRoute] = useState<Route | void>(() => {
       if (to && typeof to !== 'string') {
-        if ('then' in to) to.then(r => setRoute(r.default));
+        if ('then' in to)
+          to.then(r => setRoute('default' in r ? r.default : r));
         else return to;
       }
     });

--- a/src/ui/link/index.tsx
+++ b/src/ui/link/index.tsx
@@ -32,7 +32,11 @@ const Link = forwardRef<HTMLButtonElement | HTMLAnchorElement, LinkProps>(
       }
     });
 
-    const routeAttributes = { params, query, basePath: '' };
+    const routeAttributes = {
+      params,
+      query,
+      basePath: routerActions.getBasePath() as any,
+    };
     const linkDestination = href
       ? typeof href !== 'string'
         ? createPath(href)

--- a/src/ui/link/index.tsx
+++ b/src/ui/link/index.tsx
@@ -38,15 +38,16 @@ const Link = forwardRef<HTMLButtonElement | HTMLAnchorElement, LinkProps>(
       query,
       basePath: routerActions.getBasePath() as any,
     };
-    const linkDestination = href
-      ? typeof href !== 'string'
-        ? createPath(href)
-        : href
-      : typeof to !== 'string'
-      ? (route &&
-          createPath(generateLocationFromPath(route.path, routeAttributes))) ||
-        ''
-      : to;
+    const linkDestination =
+      href != null
+        ? href
+        : typeof to !== 'string'
+        ? (route &&
+            createPath(
+              generateLocationFromPath(route.path, routeAttributes)
+            )) ||
+          ''
+        : to;
 
     const handleLinkPress = (e: any) =>
       handleNavigation(e, {

--- a/src/ui/link/utils/handle-navigation.tsx
+++ b/src/ui/link/utils/handle-navigation.tsx
@@ -1,4 +1,5 @@
 import { KeyboardEvent, MouseEvent } from 'react';
+import { Route } from '../../../common/types';
 
 import { isKeyboardEvent, isModifiedEvent } from '../../../common/utils/event';
 
@@ -9,15 +10,18 @@ type LinkPressArgs = {
   routerActions: {
     push: (href: string) => void;
     replace: (href: string) => void;
+    pushTo: (route: Route, attributes: any) => void;
+    replaceTo: (route: Route, attributes: any) => void;
   };
   replace: boolean;
   href: string;
   onClick?: (e: LinkNavigationEvent) => void;
+  to: [Route, any] | void;
 };
 
 export const handleNavigation = (
   event: any,
-  { onClick, target, replace, routerActions, href }: LinkPressArgs
+  { onClick, target, replace, routerActions, href, to }: LinkPressArgs
 ): void => {
   if (isKeyboardEvent(event) && event.keyCode !== 13) {
     return;
@@ -32,7 +36,12 @@ export const handleNavigation = (
     !isModifiedEvent(event) // ignore clicks with modifier keys
   ) {
     event.preventDefault();
-    const method = replace ? routerActions.replace : routerActions.push;
-    method(href);
+    if (to) {
+      const method = replace ? routerActions.replaceTo : routerActions.pushTo;
+      method(...to);
+    } else {
+      const method = replace ? routerActions.replace : routerActions.push;
+      method(href);
+    }
   }
 };


### PR DESCRIPTION
Couple of new APIs to allow better and future optimisations:
- `Link` prop `to` now accepts a route (as object or dynamic import), and will automatically build links using `params` and `query` additional props
- `pushTo` and `replaceTo` actions to push/replace by providing a route instead of a string
- `Router` prop `initialRoute` to avoid scanning all routes on initialisation

Moreover `matchRoute` result is now cached, so looking for the same location will avoid looping through all route definitions over and over.

TODO:
- [x] add examples 
- [x] add docs
