### PR TITLE
Add createRouterSelector API

### DIFF
--- a/docs/api/hooks.md
+++ b/docs/api/hooks.md
@@ -50,6 +50,22 @@ export const MyRouteComponent = () => {
 };
 ```
 
+If you are worried about `useRouter` re-rendering too much, you can create custom router hooks using selectors that will trigger a re-render only when the selector output changes.  
+To access/manipulate path or query parameters we still suggest to use `usePathParam` or `useQueryParam`, as they provide a simplified interface for that data.
+Also note that this utility will only return state, not actions. To access actions, combine it with [useRouterActions](#userouteractions).
+
+```js
+import { createRouterSelector } from 'react-resource-router';
+
+const useRouteName = createRouterSelector(o => o.route.name);
+
+export const MyRouteComponent = () => {
+  const routeName = useRouteName();
+
+  return <MyComponent currentRouteName={routeName} push={routerActions.push} />;
+};
+```
+
 ## useRouterActions
 
 You can access [Router Actions](#routeractions) using this hook.
@@ -122,7 +138,7 @@ export const MyComponent = () => {
   const replaceClickHandler = () => {
     setProjectId('333', 'replace');
     // => Will relace current route to /projects/333/board/456?foo=bar
-  }
+  };
 
   return (
     <div>

--- a/examples/hooks/index.tsx
+++ b/examples/hooks/index.tsx
@@ -5,6 +5,7 @@ import {
   Router,
   RouteComponent,
   createBrowserHistory,
+  createRouterSelector,
 } from 'react-resource-router';
 
 import Home from './home';
@@ -12,6 +13,7 @@ import QueryParamExample from './use-query-param';
 import PathParamExample from './use-path-param';
 
 const myHistory = createBrowserHistory();
+const useRouteName = createRouterSelector(s => s.route.name);
 
 const appRoutes = [
   {
@@ -37,9 +39,16 @@ const appRoutes = [
   },
 ];
 
+const Title = () => {
+  const title = useRouteName();
+
+  return <p>Page: {title}</p>;
+};
+
 const App = () => {
   return (
     <Router routes={appRoutes} history={myHistory} basePath="/hooks">
+      <Title />
       <RouteComponent />
     </Router>
   );

--- a/src/__tests__/unit/controllers/router-store/test.tsx
+++ b/src/__tests__/unit/controllers/router-store/test.tsx
@@ -11,6 +11,7 @@ import { MemoryRouter } from '../../../../controllers/memory-router';
 import { getResourceStore } from '../../../../controllers/resource-store';
 import { createResource } from '../../../../controllers/resource-utils';
 import {
+  createRouterSelector,
   getRouterState,
   getRouterStore,
   INITIAL_STATE,
@@ -724,6 +725,22 @@ describe('SPA Router store', () => {
 
       expect(dataA1 === dataA2).toBeTruthy();
       expect(componentRenderStates.includes('data:null')).toBeFalsy();
+    });
+  });
+
+  describe('createRouterSelector', () => {
+    it('should return selected state', () => {
+      const useRouteName = createRouterSelector(s => s.route.name);
+      const RouteName = () => <>{useRouteName()}</>;
+      const route = { path: '', name: 'home', component: () => null };
+
+      const wrapper = mount(
+        <MemoryRouter routes={[route]}>
+          <RouteName />
+        </MemoryRouter>
+      );
+
+      expect(wrapper.html()).toEqual('home');
     });
   });
 });

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -14,4 +14,7 @@ export {
 } from './hooks';
 export { useResourceStoreContext } from './resource-store';
 export { createResource } from './resource-utils';
-export { RouteResourceEnabledSubscriber } from './router-store';
+export {
+  RouteResourceEnabledSubscriber,
+  createRouterSelector,
+} from './router-store';

--- a/src/controllers/router-store/index.tsx
+++ b/src/controllers/router-store/index.tsx
@@ -26,6 +26,7 @@ import {
   ContainerProps,
   UniversalRouterContainerProps,
   EntireRouterState,
+  RouterState,
 } from './types';
 
 import { Query } from '../../common/types';
@@ -359,6 +360,20 @@ export const useRouterStoreStatic = createHook<
 >(RouterStore, {
   selector: null,
 });
+
+/**
+ * Utility to create custom hooks without re-rendering on route change
+ */
+export function createRouterSelector<T>(selector: (state: RouterState) => T) {
+  const useHook = createHook<EntireRouterState, AllRouterActions, T>(
+    RouterStore,
+    { selector }
+  );
+
+  return function useRouterSelector() {
+    return useHook()[0];
+  };
+}
 
 export const getRouterStore = () =>
   // @ts-ignore calling `getStore` without providing a scopeId

--- a/src/controllers/router/types.ts
+++ b/src/controllers/router/types.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { PropsWithChildren } from 'react';
 
 import {
   BrowserHistory,
@@ -7,12 +7,11 @@ import {
   Routes,
 } from '../../common/types';
 
-export type RouterProps = {
+export type RouterProps = PropsWithChildren<{
   isStatic: boolean;
   history: BrowserHistory;
   resourceContext?: ResourceStoreContext;
   resourceData?: ResourceStoreData;
   basePath?: string;
   routes: Routes;
-  children: ReactNode;
-};
+}>;

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -76,6 +76,10 @@ declare export function useRouter(): [
 ];
 declare export function useRouterActions(): BoundActions<RouterActionsType>;
 declare export function useResourceStoreContext(): ResourceStoreContext;
+declare export function createRouterSelector<T>(
+  selector: (state: RouterState) => T
+): () => T;
+
 declare export function useQueryParam(
   paramKey: string
 ): [

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export {
   useResourceStoreContext,
   createResource,
   useRouterActions,
+  createRouterSelector,
 } from './controllers';
 
 export { RouteComponent, Link } from './ui';


### PR DESCRIPTION
Expose a `createRouterSelector` that returns a hook to access a selected part of the router store.

```js
const useRouteName = createRouterSelector(s => s.route.name);
```

Closes #57