### PR TITLE
Remove deprecated type from withRouter

### DIFF
--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -99,10 +99,7 @@ declare export function withRouter<
   Component: ComponentType<Props>
 >(
   WrappedComponent: Component
-): ComponentType<
-  // $FlowFixMe[deprecated-utility] - $Supertype is deprecated https://github.com/flow-typed/flow-typed/issues/2991
-  $Diff<ElementConfig<$Supertype<Component>>, WithRouterProps>
->;
+): ComponentType<$Diff<ElementConfig<Component>, WithRouterProps>>;
 
 declare export function generatePath(
   pattern: string,


### PR DESCRIPTION
Fixing the flowtype for withRouter to remove implicit any, which fixes props not being checked on HOC.

https://github.com/flow-typed/flow-typed/blob/master/definitions/npm/react-router-dom_v5.x.x/flow_v0.98.x-v0.103.x/react-router-dom_v5.x.x.js#L155