### PR TITLE
Expose useResource type

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -111,6 +111,13 @@ export type RouteResourceResponse<
 
 export type RouterDataContext = RouterContext & ResourceFetchContext;
 
+export type UseResourceHookResponse<RouteResourceData> = RouteResourceResponse<
+  RouteResourceData
+  > & {
+  update: (getNewData: RouteResourceUpdater<RouteResourceData>) => void;
+  refresh: () => void;
+};
+
 export type RouteResourceGettersArgs = [
   RouterDataContext,
   ResourceStoreContext

--- a/src/controllers/hooks/resource-store/index.tsx
+++ b/src/controllers/hooks/resource-store/index.tsx
@@ -5,18 +5,12 @@ import {
   RouteResourceResponse,
   RouteResourceUpdater,
   RouterContext,
+  UseResourceHookResponse,
 } from '../../../common/types';
 import { useResourceActions, useResourceStore } from '../../resource-store';
 import { useRouterStoreStatic, RouterStore } from '../../router-store';
 import { EntireRouterState, AllRouterActions } from '../../router-store/types';
 import { createHook } from 'react-sweet-state';
-
-type UseResourceHookResponse<RouteResourceData> = RouteResourceResponse<
-  RouteResourceData
-> & {
-  update: (getNewData: RouteResourceUpdater<RouteResourceData>) => void;
-  refresh: () => void;
-};
 
 type UseResourceOptions = {
   routerContext?: RouterContext;

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,7 @@ export {
   RouteResourceUpdater,
   RouterContext,
   RouterDataContext,
+  UseResourceHookResponse,
 } from './common/types';
 
 export {


### PR DESCRIPTION
- moving `UseResourceHookResponse` to common types
- exposing it among others
- kudos to @MonicaOlejniczak for exporting the vast majority of other types(#74), this seems to be the very last piece.

## What
The end goal - expose the result type of `useResource`.


## Why
Because one cannot use generics for `ReturnType<typeof useResource>` and type harness partially disappear after such operations if and when they are required.