### PR TITLE
Add generics for typing resource data in Flow types

### DIFF
--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -42,14 +42,14 @@ declare export function Router(props: RouterProps): Node;
 declare export function MemoryRouter(props: MemoryRouterProps): Node;
 declare export function StaticRouter(props: StaticRouterProps): Node;
 
-declare export function ResourceSubscriber(props: {
+declare export function ResourceSubscriber<T>(props: {
   children: (
-    resource: RouteResourceResponse & {
-      update: (getNewData: RouteResourceUpdater<RouteResourceData>) => void,
+    resource: RouteResourceResponse<T> & {
+      update: (getNewData: RouteResourceUpdater<RouteResourceData<T>>) => void,
       refresh: () => void,
     }
   ) => Node,
-  resource: RouteResource,
+  resource: RouteResource<T>,
 }): Node;
 declare export function RouterSubscriber(props: RouterSubscriberProps): Node;
 
@@ -61,12 +61,12 @@ declare export function RouteComponent(): Node;
 
 // hooks
 
-declare export function useResource(
-  resource: RouteResource,
+declare export function useResource<T>(
+  resource: RouteResource<T>,
   options?: ResourceOptions
 ): {|
-  ...RouteResourceResponse,
-  update: (getNewData: RouteResourceUpdater<RouteResourceData>) => void,
+  ...RouteResourceResponse<T>,
+  update: (getNewData: RouteResourceUpdater<T>) => void,
   refresh: () => void,
 |};
 declare export function useRouter(): [RouterState, RouterActionsType];
@@ -120,8 +120,8 @@ declare export function createRouterContext(
  * Utility method to created async versions of getData functions
  *
  */
-type GetDataLoader = () => Promise<{
-  default: $PropertyType<RouteResource, 'getData'>,
+type GetDataLoader<T> = () => Promise<{
+  default: $PropertyType<RouteResource<T>, 'getData'>,
   ...
 }>;
 
@@ -129,15 +129,15 @@ type GetDataLoader = () => Promise<{
  * Utility method to created type safe resources with defaults.
  *
  */
-type CreateResourceArg =
-  | {| ...RouteResource, maxAge?: number |}
+type CreateResourceArg<T> =
+  | {| ...RouteResource<T>, maxAge?: number |}
   | {|
       ...$Diff<
-        RouteResource,
-        {| getData: $ElementType<RouteResource, 'getData'> |}
+        RouteResource<T>,
+        {| getData: $PropertyType<RouteResource<T>, 'getData'> |}
       >,
       maxAge?: number,
-      getDataLoader: GetDataLoader,
+      getDataLoader: GetDataLoader<T>,
     |};
 
-declare export function createResource(args: CreateResourceArg): RouteResource;
+declare export function createResource<T>(args: CreateResourceArg<T>): RouteResource<T>;

--- a/src/mocks.js.flow
+++ b/src/mocks.js.flow
@@ -30,5 +30,5 @@ declare export function mockRouteContextProp(
   key: string,
   mock: { ... }
 ): RouteContext;
-declare export var mockRouteResourceResponse: RouteResourceResponse;
+declare export var mockRouteResourceResponse: RouteResourceResponse<mixed>;
 declare export var mockRoutes: Route[];

--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -47,17 +47,19 @@ export type RouteContext = {|
   action: HistoryAction,
 |};
 
-type RouteResourceLoading = boolean;
-type RouteResourceTimestamp = number | null;
+export type RouteResourceLoading = boolean;
+export type RouteResourceTimestamp = number | null;
 export type RouteResourceError = Object | Error | null;
-export type RouteResourceData = Object | null;
-type RouteResourcePromise = Promise<any> | null;
+// Flow can't narrow optional chaining for RouteResourceResponse.data/RouteResourceResponse.promise
+// if the fields are based off RouteResourceData/RouteResourcePromise so we flip the source of truth for these fields
+export type RouteResourceData<T> = $PropertyType<RouteResourceResponse<T>, 'data'>;
+export type RouteResourcePromise<T> = $PropertyType<RouteResourceResponse<T>, 'promise'>;
 
-export type RouteResourceResponse = {|
+export type RouteResourceResponse<T> = {|
   loading: RouteResourceLoading,
   error: RouteResourceError,
-  data: RouteResourceData,
-  promise: RouteResourcePromise,
+  data: T | null,
+  promise: Promise<T> | null,
   expiresAt: RouteResourceTimestamp,
   key: string,
 |};
@@ -65,7 +67,7 @@ export type RouteResourceResponse = {|
 type ResourceFetchContext = { isPrefetch: boolean };
 export type RouterDataContext = { ...RouterContext, ...ResourceFetchContext };
 
-export type RouteResource = {|
+export type RouteResource<T> = {|
   type: string,
   getKey: (
     routerContext: RouterContext,
@@ -75,22 +77,22 @@ export type RouteResource = {|
   getData: (
     routerContext: RouterDataContext,
     customContext: ResourceStoreContext
-  ) => RouteResourcePromise,
+  ) => RouteResourcePromise<T>,
 |};
 
-export type RouteResources = RouteResource[];
+export type RouteResources = RouteResource<mixed>[];
 
 export type ResourceStoreContext = Object;
 
 type RouteResourceDataForType = {
-  [key: string]: RouteResourceResponse,
+  [key: string]: RouteResourceResponse<mixed>,
 };
 
 export type ResourceOptions = {
   routerContext?: RouterContext,
 };
 
-export type RouteResourceUpdater<T: RouteResourceData> = (data: T) => T;
+export type RouteResourceUpdater<T: RouteResourceData<any>> = (data: T) => T;
 
 export type InvariantRoute = {
   path: string,
@@ -124,7 +126,7 @@ export type Route = {
   /**
    * The resources for the route
    */
-  resources?: RouteResource[],
+  resources?: RouteResource<any>[],
 
   // allow for custom route properties
   [key: string]: any,


### PR DESCRIPTION
Right now, our Flow types don't make type guarantees for consumers of resources via `useResource` and `ResourceSubscriber`, because resource definition (and hence consumption) has no way of providing the response shape to Flow.

This PR addresses this issue, by adding generic parameters to `createResource` which are then passed through for inference by `useResource` and `ResourceSubscriber`. Please see comments on relevant places for context/discussion points. :)

----

Example diff of a consumer upgrading to consume this:
```diff
 // @flow
 import { createResource, useResource } from 'react-resource-router';
 
 type ResponseType = {
   ok: boolean,
   value: number,
 }

-const helloWorldResource = createResource({
+const helloWorldResource = createResource<ResponseType>({
   type: 'hello-world',
   getKey: () => 'global (no pun intended)',
   getData: () => Promise.resolve({ ok: true, value: 9001 }),
 }

 const Component = () => {
   const { data } = useResource(helloWorldResource);
   const value = data?.value;
-  // Flow thinks `data` is `any` so `value` is now `any` too!
-  const stringValue: string = value; // wait what?!
+  const stringValue: string = value; // Flow now errors here <3
 }
```