### PR TITLE
correction for docs to go correct page instead of 404

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,22 +1,22 @@
 - **Resources**
 
-  - [Concept](/resources/concept.md)
-  - [Creation](/resources/creation.md)
-    - [Code Splitting](/resources/creation/code-splitting.md)
-    - [Error Handling](/resources/creation/error-handling.md)
-  - [Adding](/resources/adding.md)
-  - [Usage](/resources/usage.md)
-  - [Interaction](/resources/interaction.md)
+  - [Concept](./resources/concept.md)
+  - [Creation](./resources/creation.md)
+    - [Code Splitting](./resources/creation/code-splitting.md)
+    - [Error Handling](./resources/creation/error-handling.md)
+  - [Adding](./resources/adding.md)
+  - [Usage](./resources/usage.md)
+  - [Interaction](./resources/interaction.md)
 
 * **Router**
 
-  - [Configuration](/router/configuration.md)
-  - [Selection](/router/selection.md)
-  - [State](/router/state.md)
-  - [SSR](/router/ssr.md)
+  - [Configuration](./router/configuration.md)
+  - [Selection](./router/selection.md)
+  - [State](./router/state.md)
+  - [SSR](./router/ssr.md)
 
 * **API**
 
-  - [Components](/api/components.md)
-  - [Hooks](/api/hooks.md)
-  - [Utilities](/api/utilities.md)
+  - [Components](./api/components.md)
+  - [Hooks](./api/hooks.md)
+  - [Utilities](./api/utilities.md)

--- a/docs/api/components.md
+++ b/docs/api/components.md
@@ -221,7 +221,7 @@ export const MyRouteComponent = () => (
 
 ## ResourceSubscriber
 
-The `ResourceSubscriber` is a component that is subscribed to the state of a resource. It can be used to access resource state via render props. We only recommend using this component if you are unable to use the [`useResource`](#useresource) hook.
+The `ResourceSubscriber` is a component that is subscribed to the state of a resource. It can be used to access resource state via render props. We only recommend using this component if you are unable to use the [`useResource`](./hooks.md#useresource) hook.
 
 ### ResourceSubscriber props
 

--- a/docs/api/components.md
+++ b/docs/api/components.md
@@ -1,6 +1,6 @@
 ## Router
 
-The `Router` component should ideally wrap your client app as high up in the tree as possible. As soon as it is mounted, it will match the current route and then call all of the matched resources' `getData` methods. Components that are subscribed to these resources either via the [`useResource`](/api/hooks#useresource) hook or [`ResourceSubscriber`](/api/components#resourcesubscriber) will progressively update according to the requests' lifecycles.
+The `Router` component should ideally wrap your client app as high up in the tree as possible. As soon as it is mounted, it will match the current route and then call all of the matched resources' `getData` methods. Components that are subscribed to these resources either via the [`useResource`](./hooks.md#useresource) hook or [`ResourceSubscriber`](./components.md#resourcesubscriber) will progressively update according to the requests' lifecycles.
 
 If you are planning to render your application on the server, we recommend creating a composition boundary between your router and the core of your application, including your `RouteComponent`.
 

--- a/docs/api/hooks.md
+++ b/docs/api/hooks.md
@@ -44,11 +44,11 @@ As well as returning actions that act on the resource (i.e. update and refresh),
 It is important to note that loading can be true even when there is an error. In that case, promise will be null because there is no Suspense support on the server. Developers should give priority to loading when deciding between loading or error states for their components. Promises/errors should only ever be thrown on the client
 
 It also acceps some options as second argument to customise the behaviour, like `routerContext`.
-Check out [this section](/resources/usage) for more details on how to use the `useResource` hook.
+Check out [this section](../resources/usage.md) for more details on how to use the `useResource` hook.
 
 ## useRouter
 
-You can use the `useRouter` hook to access current [route context](/api/components#routecomponent-props) as well as [router actions](/api/components#routeractions) if required.
+You can use the `useRouter` hook to access current [route context](./components.md#routecomponent-props) as well as [router actions](./components.md#routeractions) if required.
 
 ```js
 import { useRouter, RouterSubscriber, withRouter } from 'react-resource-router';

--- a/docs/api/utilities.md
+++ b/docs/api/utilities.md
@@ -1,10 +1,10 @@
 ## createResource
 
-This function is what must be used to create resources for your routes. You can read more about how to create resources [here](/resources/creation).
+This function is what must be used to create resources for your routes. You can read more about how to create resources [here](../resources/creation.md).
 
 ## createBrowserHistory
 
-This function creates a `BrowserHistory` instance. You will need to supply this to your [`Router`](/api/components#router) in your client side code. Note that a single history instance _can_ be shared between routers if you are migrating away from `react-router`.
+This function creates a `BrowserHistory` instance. You will need to supply this to your [`Router`](./components.md#router) in your client side code. Note that a single history instance _can_ be shared between routers if you are migrating away from `react-router`.
 
 ```js
 import {

--- a/docs/resources/adding.md
+++ b/docs/resources/adding.md
@@ -18,4 +18,4 @@ export const routes = [
 ];
 ```
 
-Here we have two resources being used for the dynamic user profile route. When the router mounts and matches this route, the `resources` here will all begin to fetch their data and the `UserProfile` component will be updated accordingly if it uses the [`useResource`](/api/hooks#useresource) hook or the [`ResourceSubscriber`](/api/components#resourcesubscriber) component internally.
+Here we have two resources being used for the dynamic user profile route. When the router mounts and matches this route, the `resources` here will all begin to fetch their data and the `UserProfile` component will be updated accordingly if it uses the [`useResource`](../api/hooks.md#useresource) hook or the [`ResourceSubscriber`](../api/components.md#resourcesubscriber) component internally.

--- a/docs/resources/concept.md
+++ b/docs/resources/concept.md
@@ -2,6 +2,6 @@
 
 Router Resources are objects that are used by the router to fetch, cache and provide data for route components.
 
-You can create these objects using the [`createResource`](/resources/creation.md) function and then put them in the `resources` array on your route configuration object. Doing so means that each resources' data will be fetched as soon as the Router is mounted on initial page loads and on route transitions if the resources have expired.
+You can create these objects using the [`createResource`](./creation.md) function and then put them in the `resources` array on your route configuration object. Doing so means that each resources' data will be fetched as soon as the Router is mounted on initial page loads and on route transitions if the resources have expired.
 
-Since we recommend that your [`Router`](/api/components#router) sits as high up in your React tree as possible, it means that asynchronous requests for data are triggered as early as can be. This results in quicker meaningful render times.
+Since we recommend that your [`Router`](../api/components.md#router) sits as high up in your React tree as possible, it means that asynchronous requests for data are triggered as early as can be. This results in quicker meaningful render times.

--- a/docs/resources/interaction.md
+++ b/docs/resources/interaction.md
@@ -1,6 +1,6 @@
 # How to interact with Router Resources
 
-After the Router has mounted, your data has been fetched and your route component has rendered, you may need to interact with your resources in order to keep them up to date or to have them respond to certain user actions. In order to achieve this, in addition to the current resource state, both the [`useResource`](/api/hooks#useresource) hook and [`ResourceSubscriber`](/api/components#resourcesubscriber) provide `update` and `refresh` functions for you to use in your components. Let's take a look at how these work.
+After the Router has mounted, your data has been fetched and your route component has rendered, you may need to interact with your resources in order to keep them up to date or to have them respond to certain user actions. In order to achieve this, in addition to the current resource state, both the [`useResource`](../api/hooks.md#useresource) hook and [`ResourceSubscriber`](../api/components.md#resourcesubscriber) provide `update` and `refresh` functions for you to use in your components. Let's take a look at how these work.
 
 ## Updating
 
@@ -30,7 +30,7 @@ export const UsernameUpdater = ({ newUsername }) => {
 
 ## Refreshing
 
-The refresh function is bound to the resource that you provide to [`useResource`](/api/hooks#useresource) hook or the [`ResourceSubscriber`](/api/components#resourcesubscriber). Calling this function will cause the router to call the `getData` function on your resource, and bypass any `expiresAt` checks.
+The refresh function is bound to the resource that you provide to [`useResource`](../api/hooks.md#useresource) hook or the [`ResourceSubscriber`](../api/components.md#resourcesubscriber). Calling this function will cause the router to call the `getData` function on your resource, and bypass any `expiresAt` checks.
 
 When using the `refresh` function, the resource will always be fetched from remote and the resource state will be updated with any result, including errors.
 

--- a/docs/resources/usage.md
+++ b/docs/resources/usage.md
@@ -1,6 +1,6 @@
 # How to use Router Resources in your components
 
-Resources expose properties and functions via the [`useResource`](/api/hooks#useresource) hook or the [`ResourceSubscriber`](/api/components#resourcesubscriber), which allow their current state to be accessed or interacted with in your components. These are
+Resources expose properties and functions via the [`useResource`](../api/hooks.md#useresource) hook or the [`ResourceSubscriber`](../api/components.md#resourcesubscriber), which allow their current state to be accessed or interacted with in your components. These are
 
 | Property  | Type              | Description                                                                             |
 | --------- | ----------------- | --------------------------------------------------------------------------------------- |
@@ -15,7 +15,7 @@ You can use these properties and functions to implement your own customised rend
 
 ## Hook
 
-Using resources via the [`useResource`](/api/hooks#useresource) hook is the **recommended** way to access your current resource state in a component. Here is an example of how you can do that
+Using resources via the [`useResource`](../api/hooks.md#useresource) hook is the **recommended** way to access your current resource state in a component. Here is an example of how you can do that
 
 ```jsx
 import { useResource } from 'react-resource-router';
@@ -32,7 +32,7 @@ export const Avatar = () => {
 
 ## Component
 
-If you are unable to use the [`useResource`](/api/hooks#useresource) hook for whatever reason, you can also use the [`ResourceSubscriber`](/api/components#resourcesubscriber) component which provides your resource state via render props
+If you are unable to use the [`useResource`](../api/hooks.md#useresource) hook for whatever reason, you can also use the [`ResourceSubscriber`](../api/components.md#resourcesubscriber) component which provides your resource state via render props
 
 ```jsx
 import { ResourceSubscriber } from 'react-resource-router';

--- a/docs/router/selection.md
+++ b/docs/router/selection.md
@@ -1,3 +1,3 @@
 # Which Router should I use?
 
-React Resource Router provides three kinds of routers which should be quite familiar to anyone who has used `react-router` previously. These are the core [`Router`](/api/components#router), the [`StaticRouter`](/api/components#staticrouter) for use on the server and the [`MemoryRouter`](/api/components#memoryrouter) for use in tests. Please check the [API](/api) docs for more detailed information about these components.
+React Resource Router provides three kinds of routers which should be quite familiar to anyone who has used `react-router` previously. These are the core [`Router`](../api/components.md#router), the [`StaticRouter`](../api/components.md#staticrouter) for use on the server and the [`MemoryRouter`](../api/components.md#memoryrouter) for use in tests. Please check the [API](../api) docs for more detailed information about these components.

--- a/docs/router/state.md
+++ b/docs/router/state.md
@@ -2,8 +2,8 @@
 
 ## Accessing Router State
 
-Current router state is accessible through the [`useRouter`](/docs/api/hooks.md#userouter) hook, the [`RouterSubscriber`](/docs/api/components.md#routersubscriber-component) component or the [`withRouter`](/docs/api/components.md#withrouter) higher order component. We recommend using the hook or subscriber, as the HoC is provided in order to assist in migrating away from `react-router` if this is needed.
+Current router state is accessible through the [`useRouter`](/api/hooks#userouter) hook, the [`RouterSubscriber`](/api/components#routersubscriber-component) component or the [`withRouter`](/api/components#withrouter) higher order component. We recommend using the hook or subscriber, as the HoC is provided in order to assist in migrating away from `react-router` if this is needed.
 
 ## Interacting With History
 
-In order to imperatively change routes in your application, for example directing the user to the `login` page after they have hit the `logout` button, you can use the [`useRouterActions`](/docs/api/hooks.md#userouteractions) hook or the [`RouterActions`](/docs/api/components.md#routeractions) component. These both expose a number of methods to safely allow you to do this without providing direct access to the router's internal `history` instance.
+In order to imperatively change routes in your application, for example directing the user to the `login` page after they have hit the `logout` button, you can use the [`useRouterActions`](/api/hooks#userouteractions) hook or the [`RouterActions`](/api/components#routeractions) component. These both expose a number of methods to safely allow you to do this without providing direct access to the router's internal `history` instance.

--- a/docs/router/state.md
+++ b/docs/router/state.md
@@ -2,8 +2,8 @@
 
 ## Accessing Router State
 
-Current router state is accessible through the [`useRouter`](../api/hooks#userouter) hook, the [`RouterSubscriber`](../api/components#routersubscriber-component) component or the [`withRouter`](../api/components#withrouter) higher order component. We recommend using the hook or subscriber, as the HoC is provided in order to assist in migrating away from `react-router` if this is needed.
+Current router state is accessible through the [`useRouter`](../api/hooks.md#userouter) hook, the [`RouterSubscriber`](../api/components.md#routersubscriber-component) component or the [`withRouter`](../api/components.md#withrouter) higher order component. We recommend using the hook or subscriber, as the HoC is provided in order to assist in migrating away from `react-router` if this is needed.
 
 ## Interacting With History
 
-In order to imperatively change routes in your application, for example directing the user to the `login` page after they have hit the `logout` button, you can use the [`useRouterActions`](../api/hooks#userouteractions) hook or the [`RouterActions`](../api/components#routeractions) component. These both expose a number of methods to safely allow you to do this without providing direct access to the router's internal `history` instance.
+In order to imperatively change routes in your application, for example directing the user to the `login` page after they have hit the `logout` button, you can use the [`useRouterActions`](../api/hooks.md#userouteractions) hook or the [`RouterActions`](../api/components.md#routeractions) component. These both expose a number of methods to safely allow you to do this without providing direct access to the router's internal `history` instance.

--- a/docs/router/state.md
+++ b/docs/router/state.md
@@ -2,8 +2,8 @@
 
 ## Accessing Router State
 
-Current router state is accessible through the [`useRouter`](/api/hooks#userouter) hook, the [`RouterSubscriber`](/api/components#routersubscriber-component) component or the [`withRouter`](/api/#withrouter) higher order component. We recommend using the hook or subscriber, as the HoC is provided in order to assist in migrating away from `react-router` if this is needed.
+Current router state is accessible through the [`useRouter`](/docs/api/hooks.md#userouter) hook, the [`RouterSubscriber`](/docs/api/components.md#routersubscriber-component) component or the [`withRouter`](/docs/api/components.md#withrouter) higher order component. We recommend using the hook or subscriber, as the HoC is provided in order to assist in migrating away from `react-router` if this is needed.
 
 ## Interacting With History
 
-In order to imperatively change routes in your application, for example directing the user to the `login` page after they have hit the `logout` button, you can use the [`useRouterActions`](/api/hooks#userouteractions) hook or the [`RouterActions`](/api/components#routeractions) component. These both expose a number of methods to safely allow you to do this without providing direct access to the router's internal `history` instance.
+In order to imperatively change routes in your application, for example directing the user to the `login` page after they have hit the `logout` button, you can use the [`useRouterActions`](/docs/api/hooks.md#userouteractions) hook or the [`RouterActions`](/docs/api/components.md#routeractions) component. These both expose a number of methods to safely allow you to do this without providing direct access to the router's internal `history` instance.

--- a/docs/router/state.md
+++ b/docs/router/state.md
@@ -2,8 +2,8 @@
 
 ## Accessing Router State
 
-Current router state is accessible through the [`useRouter`](/api/hooks#userouter) hook, the [`RouterSubscriber`](/api/components#routersubscriber-component) component or the [`withRouter`](/api/components#withrouter) higher order component. We recommend using the hook or subscriber, as the HoC is provided in order to assist in migrating away from `react-router` if this is needed.
+Current router state is accessible through the [`useRouter`](../api/hooks#userouter) hook, the [`RouterSubscriber`](../api/components#routersubscriber-component) component or the [`withRouter`](../api/components#withrouter) higher order component. We recommend using the hook or subscriber, as the HoC is provided in order to assist in migrating away from `react-router` if this is needed.
 
 ## Interacting With History
 
-In order to imperatively change routes in your application, for example directing the user to the `login` page after they have hit the `logout` button, you can use the [`useRouterActions`](/api/hooks#userouteractions) hook or the [`RouterActions`](/api/components#routeractions) component. These both expose a number of methods to safely allow you to do this without providing direct access to the router's internal `history` instance.
+In order to imperatively change routes in your application, for example directing the user to the `login` page after they have hit the `logout` button, you can use the [`useRouterActions`](../api/hooks#userouteractions) hook or the [`RouterActions`](../api/components#routeractions) component. These both expose a number of methods to safely allow you to do this without providing direct access to the router's internal `history` instance.


### PR DESCRIPTION
Some of the links in docs are going to 404 due to missing folder/extension name in url or typos.