### PR TITLE
Fixed URLs to work with both generated docs and github itself

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,28 +23,7 @@ React Resource Router was developed by Atlassian for [Jira](https://www.atlassia
 
 ### Create your resources
 
-Resources describe and provide the data required for your route. This data is safely stored and accessed via the [`useResource`](/api/hooks#use-resource) hook or [`ResourceSubscriber`](/api/components#resourcesubscriber) component.
-
-```js
-import { createResource } from 'react-resource-router';
-import { fetch } from '../common/utils';
-
-export const homeResource = createResource({
-  type: 'HOME',
-  getKey: () => 'home-resource-key',
-  getData: () => fetch('https://my-api.com/home'),
-});
-
-export const aboutResource = createResource({
-  type: 'ABOUT',
-  getKey: () => 'about-resource-key',
-  getData: () => fetch('https://my-api.com/about'),
-});
-```
-
-### Create your components
-
-These are the React components that get rendered for your routes. As mentioned, they can be wired into the state of your resources via the [`useResource`](/api/hooks#use-resource) hook or [`ResourceSubscriber`](/api/components#resourcesubscriber) component.
+Resources describe and provide the data required for your route. This data is safely stored and accessed via the [`useResource`](api/hooks.md#use-resource) hook or [`ResourceSubscriber`](api/components#resourcesubscriber) component.
 
 ```js
 import { useResource } from 'react-resource-router';
@@ -82,7 +61,7 @@ export const About = () => {
 
 ### Create your routes
 
-Your [route configuration](/router/configuration#how-to-configure-the-router) is the single source of truth for your application's routing concerns.
+Your [route configuration](router/configuration#how-to-configure-the-router) is the single source of truth for your application's routing concerns.
 
 ```js
 import { Home, About } from '../components';

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ React Resource Router was developed by Atlassian for [Jira](https://www.atlassia
 
 ### Create your resources
 
-Resources describe and provide the data required for your route. This data is safely stored and accessed via the [`useResource`](api/hooks.md#use-resource) hook or [`ResourceSubscriber`](api/components#resourcesubscriber) component.
+Resources describe and provide the data required for your route. This data is safely stored and accessed via the [`useResource`](api/hooks.md#use-resource) hook or [`ResourceSubscriber`](api/components.md#resourcesubscriber) component.
 
 ```js
 import { useResource } from 'react-resource-router';
@@ -61,7 +61,7 @@ export const About = () => {
 
 ### Create your routes
 
-Your [route configuration](router/configuration#how-to-configure-the-router) is the single source of truth for your application's routing concerns.
+Your [route configuration](router/configuration.md#how-to-configure-the-router) is the single source of truth for your application's routing concerns.
 
 ```js
 import { Home, About } from '../components';
@@ -87,7 +87,7 @@ export const appRoutes = [
 
 ### Use the Router
 
-Now that you've set up your resources, components and configuration correctly, all you need to do is mount the [Router](/api/components#router) in your react tree with a [`RouteComponent`](/api/components#routecomponent) as a child. It will do the rest!
+Now that you've set up your resources, components and configuration correctly, all you need to do is mount the [Router](api/components.md#router) in your react tree with a [`RouteComponent`](api/components.md#routecomponent) as a child. It will do the rest!
 
 ```js
 import {

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,25 @@ React Resource Router was developed by Atlassian for [Jira](https://www.atlassia
 Resources describe and provide the data required for your route. This data is safely stored and accessed via the [`useResource`](api/hooks.md#use-resource) hook or [`ResourceSubscriber`](api/components.md#resourcesubscriber) component.
 
 ```js
+import { createResource } from 'react-resource-router';
+import { fetch } from '../common/utils';
+export const homeResource = createResource({
+  type: 'HOME',
+  getKey: () => 'home-resource-key',
+  getData: () => fetch('https://my-api.com/home'),
+});
+export const aboutResource = createResource({
+  type: 'ABOUT',
+  getKey: () => 'about-resource-key',
+  getData: () => fetch('https://my-api.com/about'),
+});
+```
+
+### Create your components
+
+These are the React components that get rendered for your routes. As mentioned, they can be wired into the state of your resources via the [`useResource`](api/hooks.md#use-resource) hook or [`ResourceSubscriber`](api/components.md#resourcesubscriber) component.
+
+```js
 import { useResource } from 'react-resource-router';
 import { aboutResource, homeResource } from '../routes/resources';
 import { Loading, Error } from './common';

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,11 +28,13 @@ Resources describe and provide the data required for your route. This data is sa
 ```js
 import { createResource } from 'react-resource-router';
 import { fetch } from '../common/utils';
+
 export const homeResource = createResource({
   type: 'HOME',
   getKey: () => 'home-resource-key',
   getData: () => fetch('https://my-api.com/home'),
 });
+
 export const aboutResource = createResource({
   type: 'ABOUT',
   getKey: () => 'about-resource-key',


### PR DESCRIPTION
Inline links from main file in docs are broken as they point to absolute path and does not point to md files.