### PR TITLE
ensure consistent resource promise

### DIFF
--- a/docs/api/hooks.md
+++ b/docs/api/hooks.md
@@ -33,17 +33,22 @@ export const Feed = () => {
 
 As well as returning actions that act on the resource (i.e. update and refresh), `useResource` returns four different properties that indicate the state of the resource. These four are `data`, `loading`, `error` and `promise`. `useResource` will return different combinations of these four properties depending on the state of the resource. The table below shows all the possible combinations.
 
-|           state           |    data    | loading |     error     | promise |
-| :-----------------------: | :--------: | :-----: | :-----------: | :-----: |
-|           idle            |    null    |  false  |     null      |  null   |
-|          loading          | null or {} |  true   | null or Error | Promise |
-| loading after ssr timeout |    null    |  true   | TimeoutError  |  null   |
-|     fetch successful      |     {}     |  false  |     null      | Promise |
-|        fetch error        | null or {} |  false  |     Error     | Promise |
+|           state              |    data   | loading |     error     | promise                           |
+| :--------------------------: | :-------: | :-----: | :-----------: | :-------------------------------: |
+|     initial                  |    null   |  false  |     null      |  null                             |
+|     data (from SSR)          |     {}    |  false  |     null      | Promise (resolves `data`)         |
+|     timeout (from SSR)       |    null   |  true   | TimeoutError  |  null                             |
+|     async loading            | _-prev-_  |  true   | _-prev-_      | Promise (pending)                 |
+|     async successful         |     {}    |  false  |     null      | Promise (resolves `data`)         |
+|     async error              | _-prev-_  |  false  | Error         | Promise (rejects `error`)         |
+|     updated `null` (deleted) |    null   |  false  |     null      |  null                             |
+|     updated {}               |    {}     |  false  |     null      | Promise (resolves updated `data`) |
 
-It is important to note that loading can be true even when there is an error. In that case, promise will be null because there is no Suspense support on the server. Developers should give priority to loading when deciding between loading or error states for their components. Promises/errors should only ever be thrown on the client
+Where `-prev-` indicates the field will remain unchanged from any previous state, possibly the inital state.
 
-It also acceps some options as second argument to customise the behaviour, like `routerContext`.
+It is important to note that the timeout state is essentially a hung loading state, with the difference that `promise = null` and `error != null`. Developers should give priority to `loading` when deciding between loading or error states for their components. Promises/errors should only ever be thrown on the client.
+
+Additionaly `useResource` accepts additional arguments to customise behaviour, like `routerContext`.
 Check out [this section](../resources/usage.md) for more details on how to use the `useResource` hook.
 
 ## useRouter

--- a/src/__tests__/unit/controllers/static-router/test.tsx
+++ b/src/__tests__/unit/controllers/static-router/test.tsx
@@ -57,11 +57,10 @@ describe('<StaticRouter />', () => {
     const result = 'result';
     const resolver = (r: any, d = 0) =>
       new Promise(resolve => setTimeout(() => resolve(r), d));
-    const getDataPromise = Promise.resolve(result);
     const mockResource = {
       type,
       getKey: () => key,
-      getData: () => getDataPromise,
+      getData: () => Promise.resolve(result),
     };
     const mockedRoutes = [
       {

--- a/src/__tests__/unit/ui/link/test.tsx
+++ b/src/__tests__/unit/ui/link/test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { mount } from 'enzyme';
 import { defaultRegistry } from 'react-sweet-state';
+import { act } from 'react-dom/test-utils';
 
 import { LinkProps } from '../../../../common/types';
 import { Router } from '../../../../controllers/router';
@@ -102,7 +103,9 @@ describe('<Link />', () => {
     const wrapper = mountInRouter('my link', { href: newPath });
     const component = wrapper.find('Link');
 
-    component.simulate('click', baseClickEvent);
+    act(() => {
+      component.simulate('click', baseClickEvent);
+    });
 
     expect(HistoryMock.push).toHaveBeenCalledTimes(1);
     expect(HistoryMock.push).toHaveBeenCalledWith(newPath);
@@ -112,7 +115,9 @@ describe('<Link />', () => {
     const wrapper = mountInRouter('my link', { href: newPath });
     const component = wrapper.find('Link');
 
-    component.simulate('click', baseClickEvent);
+    act(() => {
+      component.simulate('click', baseClickEvent);
+    });
 
     expect(baseClickEvent.preventDefault).toHaveBeenCalledTimes(1);
   });
@@ -125,7 +130,9 @@ describe('<Link />', () => {
     });
     const component = wrapper.find('Link');
 
-    component.simulate('click', baseClickEvent);
+    act(() => {
+      component.simulate('click', baseClickEvent);
+    });
 
     expect(mockOnClick).toHaveBeenCalledTimes(1);
     expect(baseClickEvent.preventDefault).toHaveBeenCalledTimes(1);
@@ -136,7 +143,9 @@ describe('<Link />', () => {
     const wrapper = mountInRouter('my link', { href: newPath, replace: true });
     const component = wrapper.find('Link');
 
-    component.simulate('click', baseClickEvent);
+    act(() => {
+      component.simulate('click', baseClickEvent);
+    });
 
     expect(HistoryMock.replace).toHaveBeenCalledTimes(1);
     expect(HistoryMock.replace).toHaveBeenCalledWith(newPath);
@@ -149,7 +158,9 @@ describe('<Link />', () => {
         const wrapper = mountInRouter('my link', { href: newPath });
         const component = wrapper.find('Link');
 
-        component.simulate('click', { ...baseClickEvent, [modifier]: true });
+        act(() => {
+          component.simulate('click', { ...baseClickEvent, [modifier]: true });
+        });
 
         expect(HistoryMock.push).toHaveBeenCalledTimes(0);
       }
@@ -159,9 +170,11 @@ describe('<Link />', () => {
       const wrapper = mountInRouter('my link', { href: newPath });
       const component = wrapper.find('Link');
 
-      component.simulate('click', {
-        ...baseClickEvent,
-        defaultPrevented: true,
+      act(() => {
+        component.simulate('click', {
+          ...baseClickEvent,
+          defaultPrevented: true,
+        });
       });
 
       expect(HistoryMock.push).toHaveBeenCalledTimes(0);
@@ -171,7 +184,9 @@ describe('<Link />', () => {
       const wrapper = mountInRouter('my link', { href: newPath });
       const component = wrapper.find('Link');
 
-      component.simulate('click', { ...baseClickEvent, button: 42 });
+      act(() => {
+        component.simulate('click', { ...baseClickEvent, button: 42 });
+      });
 
       expect(HistoryMock.push).toHaveBeenCalledTimes(0);
     });
@@ -183,7 +198,9 @@ describe('<Link />', () => {
       });
       const component = wrapper.find('Link');
 
-      component.simulate('click', baseClickEvent);
+      act(() => {
+        component.simulate('click', baseClickEvent);
+      });
 
       expect(HistoryMock.push).toHaveBeenCalledTimes(0);
     });
@@ -224,7 +241,9 @@ describe('<Link />', () => {
       );
       const component = wrapper.find('Link');
 
-      component.simulate('click', baseClickEvent);
+      act(() => {
+        component.simulate('click', baseClickEvent);
+      });
 
       expect(HistoryMock.push).toHaveBeenCalledTimes(1);
       expect(HistoryMock.push).toHaveBeenCalledWith({
@@ -243,7 +262,9 @@ describe('<Link />', () => {
       await Promise.resolve();
       const component = wrapper.find('Link');
 
-      component.simulate('click', baseClickEvent);
+      act(() => {
+        component.simulate('click', baseClickEvent);
+      });
 
       expect(wrapper.html()).toEqual(
         '<a href="/my-page/1?foo=bar" target="_self">my link</a>'
@@ -266,10 +287,12 @@ describe('<Link />', () => {
       const wrapper = mountInRouter('my link', { href: newPath });
       const component = wrapper.find('Link');
 
-      component.simulate('click', {
-        ...baseClickEvent,
-        type: 'keypress',
-        keyCode: 13,
+      act(() => {
+        component.simulate('click', {
+          ...baseClickEvent,
+          type: 'keypress',
+          keyCode: 13,
+        });
       });
 
       expect(HistoryMock.push).toHaveBeenCalledTimes(1);
@@ -280,10 +303,12 @@ describe('<Link />', () => {
       const wrapper = mountInRouter('my link', { href: newPath });
       const component = wrapper.find('Link');
 
-      component.simulate('click', {
-        ...baseClickEvent,
-        type: 'keypress',
-        keyCode: 10,
+      act(() => {
+        component.simulate('click', {
+          ...baseClickEvent,
+          type: 'keypress',
+          keyCode: 10,
+        });
       });
 
       expect(HistoryMock.push).toHaveBeenCalledTimes(0);

--- a/src/controllers/resource-store/index.tsx
+++ b/src/controllers/resource-store/index.tsx
@@ -49,11 +49,7 @@ export const actions: Actions = {
     getState,
     dispatch,
   }) => {
-    const { data: resourceStoreData } = getState();
-    const slice = getSliceForResource(
-      { data: resourceStoreData },
-      { type, key }
-    );
+    const slice = getSliceForResource(getState(), { type, key });
     const data = getNewSliceData(slice.data);
 
     dispatch(
@@ -79,12 +75,9 @@ export const actions: Actions = {
   }) => {
     const { type, getKey, maxAge } = resource;
     const { getResourceFromRemote } = actions;
-    const { data: resourceStoreData, context } = getState();
+    const { context, ...resourceStoreState } = getState();
     const key = getKey(routerStoreContext, context);
-    let cached = getSliceForResource(
-      { data: resourceStoreData },
-      { type, key }
-    );
+    let cached = getSliceForResource(resourceStoreState, { type, key });
 
     if (shouldUseCache(cached)) {
       if (isFromSsr(cached)) {
@@ -111,12 +104,12 @@ export const actions: Actions = {
   }): Promise<RouteResourceResponse<unknown>> => {
     const { type, getKey, getData, maxAge } = resource;
     const { prefetch, timeout } = options;
-    const { data: resourceStoreData, context } = getState();
+    const { context, ...resourceStoreState } = getState();
     const key = getKey(routerStoreContext, context);
-    const slice = getSliceForResource(
-      { data: resourceStoreData },
-      { type, key }
-    );
+    const slice = getSliceForResource(resourceStoreState, {
+      type,
+      key,
+    });
 
     if (slice.loading) {
       return slice;

--- a/src/controllers/resource-store/index.tsx
+++ b/src/controllers/resource-store/index.tsx
@@ -49,17 +49,24 @@ export const actions: Actions = {
     getState,
     dispatch,
   }) => {
-    const { data } = getState();
-
-    const slice = getSliceForResource({ data }, { type, key });
+    const { data: resourceStoreData } = getState();
+    const slice = getSliceForResource(
+      { data: resourceStoreData },
+      { type, key }
+    );
+    const data = getNewSliceData(slice.data);
 
     dispatch(
-      setResourceState(type, key, {
-        ...slice,
-        data: getNewSliceData(slice.data),
-        expiresAt: getExpiresAt(maxAge),
-        accessedAt: getAccessedAt(),
-      })
+      data == null
+        ? deleteResourceKey(key, type)
+        : setResourceState(type, key, {
+            ...slice,
+            data,
+            error: null,
+            promise: Promise.resolve(data),
+            expiresAt: getExpiresAt(maxAge),
+            accessedAt: getAccessedAt(),
+          })
     );
   },
   /**


### PR DESCRIPTION
Best reviewed commit at a time.

Primarily I want to ensure that the resource `promise` will always resolve `data` or reject `error`. The main culprit being `update()` where the `promise` becomes immediately mismatched with the `data`.

Timeouts should also be rejecting errors IMO but are not included here. The logic to do that is not really more complicated  but there is a more general problem that `expiresAt` and `promise` need to be set during hydration rather than being mutated on first access. I attempted this refactor but ultimately got stuck on the tests.

Additionally in the remote resource fetch
* I made the the different async results more declarative for better clarity
* covered the edge case where an explicit update aborts in-flight fetch.

I did a little work to make the tests more consistent but there is still a lot that needs doing there.

