### PR TITLE
Add expiresAt to pending state if prefetch

### DIFF
--- a/src/__tests__/unit/controllers/resource-store/test.tsx
+++ b/src/__tests__/unit/controllers/resource-store/test.tsx
@@ -903,6 +903,36 @@ describe('resource store', () => {
         expect(spy).toBeCalledTimes(0);
       });
     });
+
+    it('should set expiresAt to pending state if prefetch', async () => {
+      (getDefaultStateSlice as any).mockImplementation(() => ({
+        ...BASE_DEFAULT_STATE_SLICE,
+      }));
+      (getExpiresAt as any).mockImplementation(() => expiresAt);
+
+      const spy = jest.spyOn(storeState, 'setState');
+
+      await actions.getResourceFromRemote(
+        mockResource,
+        mockRouterStoreContext,
+        { ...mockOptions, prefetch: true }
+      );
+
+      expect(spy).toHaveBeenNthCalledWith(1, {
+        context: {},
+        data: {
+          [type]: {
+            [key]: {
+              ...BASE_DEFAULT_STATE_SLICE,
+              loading: true,
+              accessedAt: undefined,
+              expiresAt,
+              promise: expect.any(Promise),
+            },
+          },
+        },
+      });
+    });
   });
 
   describe('cleanExpiredResources', () => {

--- a/src/controllers/resource-store/index.tsx
+++ b/src/controllers/resource-store/index.tsx
@@ -127,6 +127,12 @@ export const actions: Actions = {
         context
       ),
       accessedAt: getAccessedAt(),
+      // prevent resource from being cleaned prematurely and traigger more network requests.
+      ...(options.prefetch
+        ? {
+            expiresAt: getExpiresAt(PREFETCH_MAX_AGE),
+          }
+        : {}),
     };
 
     dispatch(setResourceState(type, key, pending));


### PR DESCRIPTION
The PR addresses https://github.com/atlassian-labs/react-resource-router/issues/104

Also, make sure that hover → prefetched → click does not result in an additional network request.

The problem was that pending state was considered as expired resource being cleaned up during `prefetchNextRouteResources` and transition. 