### PR TITLE
replace window.URL with URL from url-parse

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2666,9 +2666,9 @@
       }
     },
     "@types/url-parse": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@types/url-parse/-/url-parse-1.4.3.tgz",
-      "integrity": "sha512-4kHAkbV/OfW2kb5BLVUuUMoumB3CP8rHqlw48aHvFy5tf9ER0AfOonBlX29l/DD68G70DmyhRlSYfQPSYpC5Vw==",
+      "version": "1.4.8",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@types/url-parse/-/url-parse-1.4.8.tgz",
+      "integrity": "sha512-zqqcGKyNWgTLFBxmaexGUKQyWqeG7HjXj20EuQJSJWwXe54BjX0ihIo5cJB9yAQzH8dNugJ9GvkBYMjPXs/PJw==",
       "dev": true
     },
     "@types/yargs": {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@types/lodash.noop": "^3.0.6",
     "@types/react": "^16.9.35",
     "@types/react-dom": "^16.9.8",
-    "@types/url-parse": "^1.4.3",
+    "@types/url-parse": "^1.4.8",
     "@typescript-eslint/eslint-plugin": "^2.33.0",
     "@typescript-eslint/parser": "^2.33.0",
     "babel-eslint": "^10.0.2",

--- a/src/common/utils/create-location/parse-path.ts
+++ b/src/common/utils/create-location/parse-path.ts
@@ -1,3 +1,5 @@
+import URL from 'url-parse';
+
 export function parsePath(path: string) {
   const url = new URL(path, 'ws://a.a');
   const isAbsolute = path.startsWith('/');
@@ -7,7 +9,7 @@ export function parsePath(path: string) {
 
   return {
     pathname,
-    search: url.search,
+    search: url.query,
     hash: url.hash,
   };
 }


### PR DESCRIPTION
When trying to use the latest version of RRR in JFE, we discovered `URL` is not supported in SSR runtime.

I noticed `url-parse` is already included as dep in this repo. Therefore, use `url-parse` instead of `window.URL` as a short-term solution.