### PR TITLE
Use interface instead of type for ResourceStoreContext

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -149,7 +149,7 @@ export type RouteResource<RouteResourceData = unknown> = {
 
 export type RouteResources = RouteResource[];
 
-export type ResourceStoreContext = any;
+export interface ResourceStoreContext {}
 
 export type RouteResourceDataForType = {
   [index: string]: RouteResourceResponseBase<unknown>;


### PR DESCRIPTION
This PR just changes the TypeScript typings for `ResourceStoreContext` to be an empty `interface` instead of an `any` typed `type`, so that consumers of the library can do a module declaration to extend the `ResourceStoreContext` to type their own code. 

Example:
```ts
import 'react-resource-router';
import type { MyResourceContext } from './my-resource-context';

declare module 'react-resource-router' {
    export interface ResourceStoreContext extends MyResourceContext {}
}
```

Closes #141 