### PR TITLE
fix: compile typescript with isolatedModules to remove types from runtime code

### DIFF
--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -4,7 +4,8 @@ export { MemoryRouter } from './memory-router';
 export { StaticRouter } from './static-router';
 export { RouterActions } from './router-actions';
 export { Redirect } from './redirect';
-export { withRouter, WithRouter } from './with-router';
+export { withRouter } from './with-router';
+export type { WithRouter } from './with-router';
 export {
   useResource,
   useRouter,

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,8 +18,9 @@ export {
   createResource,
   useRouterActions,
   createRouterSelector,
-  WithRouter,
 } from './controllers';
+
+export type { WithRouter } from './controllers';
 
 export { RouteComponent, Link } from './ui';
 
@@ -31,7 +32,7 @@ export {
   findRouterContext,
 } from './common/utils';
 
-export {
+export type {
   BrowserHistory,
   CreateRouterContextOptions,
   FindRouterContextOptions,
@@ -64,7 +65,7 @@ export {
   UseResourceHookResponse,
 } from './common/types';
 
-export {
+export type {
   RouterActionsType,
   RouterActionPush,
   RouterActionReplace,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "moduleResolution": "node",
     "strict": true,
     "preserveConstEnums": true,
+    "isolatedModules": true,
     "jsx": "preserve",
     "typeRoots": ["./node_modules/@types", "types"],
     "baseUrl": ".",


### PR DESCRIPTION
### Solves
- A `Warning` for webpack:
```
WARNING in ./node_modules/react-resource-router/build/esm/controllers/index.js 7:0-55
"export 'WithRouter' was not found in './with-router'
 @ ./node_modules/react-resource-router/build/esm/index.js
```
- A `Error` for esbuld
```
✘ [ERROR] No matching export in "../../../node_modules/react-resource-router/build/esm/controllers/with-router/index.js" for import "WithRouter"
```

### The fix
- activating [isolatedModules](https://www.typescriptlang.org/tsconfig#isolatedModules) to force TypeScript to remove typed from produced js, keeping only in d.ts. That removes the problem.
During the build TS will complain if type export (not import) has not been properly attributed.

### Question
There are other types exported in plain esm right now. Only `WithRouter` creates a problem

### Followup
- https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/consistent-type-imports.md (requires `typescript-eslint` update) can automatically maintain proper usage of `import/export type` in the code base.
