### PR TITLE
No longer recreating histories within render functions in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,10 @@ import {
 } from 'react-resource-router';
 import { appRoutes } from './routing/routes';
 
+const history = createBrowserHistory();
+
 const App = () => (
-  <Router routes={appRoutes} history={createBrowserHistory()}>
+  <Router routes={appRoutes} history={history}>
     <RouteComponent />
   </Router>
 );

--- a/docs/README.md
+++ b/docs/README.md
@@ -118,8 +118,10 @@ import {
 } from 'react-resource-router';
 import { appRoutes } from './routing/routes';
 
+const history = createBrowserHistory();
+
 const App = () => (
-  <Router routes={appRoutes} history={createBrowserHistory()}>
+  <Router routes={appRoutes} history={history}>
     <RouteComponent />
   </Router>
 );

--- a/docs/api/components.md
+++ b/docs/api/components.md
@@ -194,8 +194,10 @@ import {
 import { StaticNavigation } from '../components';
 import { routes } from '../routing';
 
+const history = createBrowserHistory();
+
 export const App = () => (
-  <Router history={createBrowserHistory} routes={routes}>
+  <Router history={history} routes={routes}>
     <StaticNavigation />
     <RouteComponent />
   </Router>

--- a/docs/router/ssr.md
+++ b/docs/router/ssr.md
@@ -47,8 +47,10 @@ import { Router, createBrowserHistory } from 'react-resource-router';
 import { App } from '../components';
 import { routes } from '../routing/routes';
 
+const history = createBrowserHistory();
+
 export const ClientApp = () => (
-  <Router routes={routes} history={createBrowserHistory()}>
+  <Router routes={routes} history={history}>
     <App />
   </Router>
 );


### PR DESCRIPTION
This PR makes it so that `createBrowserHistory` is no longer called again on each render function in the documentation eamples. 

**Why?**

If you look at the implementation of the history API, you'll see that it does a few things that you probably don't want to have happen on every React render like [adding event listeners](https://github.com/remix-run/history/blob/3e9dab413f4eda8d6bce565388c5ddb7aeff9f7e/packages/history/index.ts#L430).

I think the documentation should reflect this.
