### PR TITLE
Fix issue with jsdom no longer adding window.name

### DIFF
--- a/src/common/utils/is-server-environment/index.ts
+++ b/src/common/utils/is-server-environment/index.ts
@@ -1,24 +1,3 @@
-/**
- * @see https://github.com/jsdom/jsdom/releases/tag/12.0.0
- * @see https://github.com/jsdom/jsdom/issues/1537
- */
-const isJsDomEnvironment = () =>
-  window.name === 'nodejs' ||
-  navigator.userAgent.includes('Node.js') ||
-  navigator.userAgent.includes('jsdom');
-
 export const isServerEnvironment = () => {
-  if (
-    typeof process !== 'undefined' &&
-    process.versions != null &&
-    process.versions.node != null
-  ) {
-    return true;
-  }
-
-  if (isJsDomEnvironment()) {
-    return true;
-  }
-
-  return false;
+  return globalThis !== globalThis.window;
 };


### PR DESCRIPTION
jsdom no longer sets window.name - while this script doesnt entirely rely on that the whole detection can still be simplified