### PR TITLE
Add compatibility for goBack and goForward with history@5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "react-resource-router",
-      "version": "0.20.0",
+      "version": "0.20.1",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.debounce": "^4.0.8",
@@ -34,6 +34,7 @@
         "@testing-library/react": "^10.0.4",
         "@types/enzyme": "^3.10.5",
         "@types/history": "^4.7.6",
+        "@types/history-5": "npm:@types/history@^5.0.0",
         "@types/jest": "^28.1.7",
         "@types/lodash.debounce": "^4.0.6",
         "@types/lodash.noop": "^3.0.6",
@@ -3646,6 +3647,18 @@
       "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/history-5": {
+      "name": "@types/history",
+      "version": "5.0.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@types/history/-/history-5.0.0.tgz",
+      "integrity": "sha512-hy8b7Y1J8OGe6LbAjj3xniQrj3v6lsivCcrmf4TzSgPzLkhIeKgc5IZnT7ReIqmEuodjfO8EYAuoFvIrHi/+jQ==",
+      "deprecated": "This is a stub types definition. history provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "history": "*"
+      }
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
@@ -27047,6 +27060,15 @@
       "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@types/history/-/history-4.7.11.tgz",
       "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
       "dev": true
+    },
+    "@types/history-5": {
+      "version": "npm:@types/history@5.0.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@types/history/-/history-5.0.0.tgz",
+      "integrity": "sha512-hy8b7Y1J8OGe6LbAjj3xniQrj3v6lsivCcrmf4TzSgPzLkhIeKgc5IZnT7ReIqmEuodjfO8EYAuoFvIrHi/+jQ==",
+      "dev": true,
+      "requires": {
+        "history": "*"
+      }
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "@testing-library/react": "^10.0.4",
     "@types/enzyme": "^3.10.5",
     "@types/history": "^4.7.6",
+    "@types/history-5": "npm:@types/history@^5.0.0",
     "@types/jest": "^28.1.7",
     "@types/lodash.debounce": "^4.0.6",
     "@types/lodash.noop": "^3.0.6",

--- a/src/__tests__/unit/common/utils/history/test.ts
+++ b/src/__tests__/unit/common/utils/history/test.ts
@@ -138,7 +138,11 @@ describe('createLegacyHistory', () => {
     it('should go back in history via history', () => {
       const history = createLegacyHistory();
       window.history.back = jest.fn();
-      history.goBack();
+      if ('goBack' in history) {
+        history.goBack();
+      } else {
+        throw new Error('goBack was expected but not found');
+      }
       expect(window.history.back).toHaveBeenCalled();
     });
   });
@@ -147,7 +151,11 @@ describe('createLegacyHistory', () => {
     it('should go forward in history via history', () => {
       const history = createLegacyHistory();
       window.history.forward = jest.fn();
-      history.goForward();
+      if ('goForward' in history) {
+        history.goForward();
+      } else {
+        throw new Error('goForward was expected but not found');
+      }
       expect(window.history.forward).toHaveBeenCalled();
     });
   });

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -9,6 +9,7 @@ import {
 } from 'react';
 
 import { History, Location as HistoryLocationShape } from 'history';
+import { History as History5 } from 'history-5';
 
 export type LocationShape = HistoryLocationShape;
 
@@ -20,10 +21,10 @@ export type Location = {
   hash: string;
 };
 
-export type BrowserHistory = Omit<
-  History,
-  'location' | 'go' | 'createHref' | 'push' | 'replace'
-> & {
+export type BrowserHistory = (
+  | Omit<History, 'location' | 'go' | 'createHref' | 'push' | 'replace'>
+  | Omit<History5, 'location' | 'go' | 'createHref' | 'push' | 'replace'>
+) & {
   location: Location;
   push: (path: string) => void;
   replace: (path: string) => void;

--- a/src/controllers/router-store/index.tsx
+++ b/src/controllers/router-store/index.tsx
@@ -309,6 +309,7 @@ const actions: AllRouterActions = {
     ({ getState }) => {
       const { history } = getState();
 
+      // history@4 uses goBack(), history@5 uses back()
       if ('goBack' in history) {
         history.goBack();
       } else if ('back' in history) {
@@ -323,6 +324,7 @@ const actions: AllRouterActions = {
     ({ getState }) => {
       const { history } = getState();
 
+      // history@4 uses goForward(), history@5 uses forward()
       if ('goForward' in history) {
         history.goForward();
       } else if ('forward' in history) {

--- a/src/controllers/router-store/index.tsx
+++ b/src/controllers/router-store/index.tsx
@@ -309,7 +309,13 @@ const actions: AllRouterActions = {
     ({ getState }) => {
       const { history } = getState();
 
-      history.goBack();
+      if ('goBack' in history) {
+        history.goBack();
+      } else if ('back' in history) {
+        history.back();
+      } else {
+        throw new Error('History does not support goBack');
+      }
     },
 
   goForward:
@@ -317,7 +323,13 @@ const actions: AllRouterActions = {
     ({ getState }) => {
       const { history } = getState();
 
-      history.goForward();
+      if ('goForward' in history) {
+        history.goForward();
+      } else if ('forward' in history) {
+        history.forward();
+      } else {
+        throw new Error('History does not support goForward');
+      }
     },
 
   registerBlock:


### PR DESCRIPTION
In `history@5` the `goForward` and `goBack` functions were renamed to `forward` and `back`. This means that `react-resource-router` will currently fail on these actions when used with `history@5`.

This PR fixes that and adds compatibility for these two actions with both `history@4` and `history@5`.