### PR TITLE
Add support to additional route attributes

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -234,6 +234,11 @@ export type InvariantRoute = {
   query?: string[];
 };
 
+/**
+ * Custom additional attributes that may be present in each route definition.
+ */
+interface AdditionalRouteAttributes {}
+
 export type Route = InvariantRoute & {
   /** The component to render on match, typed explicitly */
   component: ComponentType<RouteContext>;
@@ -242,7 +247,7 @@ export type Route = InvariantRoute & {
    * The resources for the route
    */
   resources?: RouteResources;
-};
+} & AdditionalRouteAttributes;
 
 export type HistoryAction = 'PUSH' | 'REPLACE' | 'POP' | '';
 


### PR DESCRIPTION
This pull-request adds support to additional route attributes in the type definitions.

#### Background

Some applications might want or need to extend the routes to allow for additional configuration, such as supporting feature flags or adding custom business logic.
From a runtime perspective, it's possible to define additional attributes in a route. From a type perspective, the TypeScript definition for a route is sealed and cannot be extended.

#### Solution

Adding a new interface, `AdditionalRouteAttributes`, and merging it with the route allows routes to be extended from the consumer side. It's the same method we're already using to allow the consumer to set the resource store context.