### PR TITLE
Export AdditionalRouteAttributes interface

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -238,7 +238,7 @@ export type InvariantRoute = {
 /**
  * Custom additional attributes that may be present in each route definition.
  */
-interface AdditionalRouteAttributes {}
+export interface AdditionalRouteAttributes {}
 
 export type Route = InvariantRoute & {
   /** The component to render on match, typed explicitly */

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ export {
 } from './common/utils';
 
 export type {
+  AdditionalRouteAttributes,
   BrowserHistory,
   CreateRouterContextOptions,
   FindRouterContextOptions,


### PR DESCRIPTION
https://github.com/atlassian-labs/react-resource-router/pull/164 set out to allow custom attributes to be added to the `Route` type. The `AdditionalRouteAttributes` interface was not exported, so custom attributes on `Route` will currently still give type errors.

This PR resolves the issue, exporting `AdditionalRouteAttributes`. 