### PR TITLE
Rework prefetch to avoid updating store slices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ yarn.lock
 .idea
 .vscode
 src/webpack/__tests__/__fixtures__/webpack/output
+.DS_Store

--- a/examples/routing-with-resources/home.tsx
+++ b/examples/routing-with-resources/home.tsx
@@ -26,7 +26,7 @@ export const Home = () => {
         <ul>
           {breeds.slice(0, 25).map(breed => (
             <li key={breed}>
-              <Link to={aboutRoute} query={{ name: breed }}>
+              <Link to={aboutRoute} query={{ name: breed }} prefetch="hover">
                 {breed}
               </Link>
             </li>

--- a/package.json
+++ b/package.json
@@ -50,9 +50,9 @@
   },
   "scripts": {
     "build": "npm run build:clean && npm run build:types-cjs && npm run build:types-esm && npm run build:cjs && npm run build:esm",
-    "build:cjs": "babel src --out-dir build/cjs --extensions \".ts,.tsx\" --source-maps inline --ignore src/__tests__ --presets @babel/env",
+    "build:cjs": "babel src --out-dir build/cjs --extensions \".ts,.tsx\" --ignore src/__tests__ --presets @babel/env",
     "build:clean": "rm -rf ./build",
-    "build:esm": "babel src --out-dir build/esm --extensions \".ts,.tsx\" --source-maps inline --ignore src/__tests__",
+    "build:esm": "babel src --out-dir build/esm --extensions \".ts,.tsx\" --ignore src/__tests__",
     "build:types-cjs": "tsc --emitDeclarationOnly --project tsconfig.build.json --outDir build/cjs && cp src/*.flow build/cjs",
     "build:types-esm": "tsc --emitDeclarationOnly --project tsconfig.build.json --outDir build/esm && cp src/*.flow build/esm",
     "docs": "npx docsify-cli serve docs",

--- a/src/__tests__/integration/test.tsx
+++ b/src/__tests__/integration/test.tsx
@@ -226,6 +226,7 @@ describe('<Router /> integration tests', () => {
         },
       },
       executing: null,
+      prefetching: null,
     });
   });
 });

--- a/src/__tests__/unit/common/utils/history/test.ts
+++ b/src/__tests__/unit/common/utils/history/test.ts
@@ -121,7 +121,7 @@ describe('createLegacyHistory', () => {
       const history = createLegacyHistory();
       history.push(null as any);
       expect(spy).toHaveBeenCalledWith('/');
-    })
+    });
 
     it('should change location via page reload', async () => {
       const history = createLegacyHistory();
@@ -144,7 +144,7 @@ describe('createLegacyHistory', () => {
       const history = createLegacyHistory();
       history.replace(null as any);
       expect(window.history.replaceState).toHaveBeenCalledWith({}, '', '/');
-    })
+    });
 
     it('should replace location via history', () => {
       window.history.replaceState = jest.fn();

--- a/src/__tests__/unit/controllers/resource-store/utils/dependent-resources/test.tsx
+++ b/src/__tests__/unit/controllers/resource-store/utils/dependent-resources/test.tsx
@@ -9,7 +9,7 @@ import {
 import {
   ResourceType,
   RouteResource,
-  RouteResourceResponseBase,
+  RouteResourceResponse,
 } from '../../../../../../common/types';
 import { State } from '../../../../../../controllers/resource-store/types';
 import { createResource } from '../../../../../../controllers/resource-utils';
@@ -454,8 +454,8 @@ describe('dependent resources', () => {
   });
 
   describe('getDependencies', () => {
-    const slice1 = { data: 1 } as RouteResourceResponseBase<number>;
-    const slice2 = { data: 2 } as RouteResourceResponseBase<number>;
+    const slice1 = { data: 1 } as RouteResourceResponse<number>;
+    const slice2 = { data: 2 } as RouteResourceResponse<number>;
 
     it('should return empty object where given resource has no dependencies', () => {
       const mockApi = createApi({ executing: [] });
@@ -463,14 +463,16 @@ describe('dependent resources', () => {
       expect(
         getDependencies(
           { depends: null } as RouteResource,
-          mockRouterStoreContext
+          mockRouterStoreContext,
+          {}
         )(mockApi)
       ).toEqual({});
 
       expect(
         getDependencies(
           { depends: [] as ResourceType[] } as RouteResource,
-          mockRouterStoreContext
+          mockRouterStoreContext,
+          {}
         )(mockApi)
       ).toEqual({});
 
@@ -481,7 +483,7 @@ describe('dependent resources', () => {
       const mockApi = createApi({ executing: null });
 
       expect(() =>
-        getDependencies(resourceY, mockRouterStoreContext)(mockApi)
+        getDependencies(resourceY, mockRouterStoreContext, {})(mockApi)
       ).toThrow(
         new ResourceDependencyError(
           'Missing resource: "y" has dependencies so must not be missing'
@@ -500,7 +502,7 @@ describe('dependent resources', () => {
       });
 
       expect(() =>
-        getDependencies(resourceZ, mockRouterStoreContext)(mockApi)
+        getDependencies(resourceZ, mockRouterStoreContext, {})(mockApi)
       ).toThrow(
         new ResourceDependencyError(
           'Missing resource: "z" has dependencies so must not be missing'
@@ -525,7 +527,8 @@ describe('dependent resources', () => {
       expect(() =>
         getDependencies(
           { ...resourceY, depends: ['a', 'b'] } as RouteResource,
-          mockRouterStoreContext
+          mockRouterStoreContext,
+          {}
         )(mockApi)
       ).toThrow(
         new ResourceDependencyError(
@@ -536,7 +539,8 @@ describe('dependent resources', () => {
       expect(() =>
         getDependencies(
           { ...resourceY, depends: ['a', 'x'] } as RouteResource,
-          mockRouterStoreContext
+          mockRouterStoreContext,
+          {}
         )(mockApi)
       ).toThrow(
         new ResourceDependencyError(
@@ -547,7 +551,8 @@ describe('dependent resources', () => {
       expect(() =>
         getDependencies(
           { ...resourceY, depends: ['y', 'b'] } as RouteResource,
-          mockRouterStoreContext
+          mockRouterStoreContext,
+          {}
         )(mockApi)
       ).toThrow(
         new ResourceDependencyError(
@@ -573,7 +578,7 @@ describe('dependent resources', () => {
       });
 
       expect(
-        getDependencies(resourceZ, mockRouterStoreContext)(mockApi)
+        getDependencies(resourceZ, mockRouterStoreContext, {})(mockApi)
       ).toEqual({
         x: slice1,
         y: slice2,
@@ -596,7 +601,7 @@ describe('dependent resources', () => {
       });
 
       expect(
-        getDependencies(resourceY, mockRouterStoreContext)(mockApi)
+        getDependencies(resourceY, mockRouterStoreContext, {})(mockApi)
       ).toEqual({
         x: slice1,
         y: slice2,
@@ -619,7 +624,7 @@ describe('dependent resources', () => {
       });
 
       expect(() =>
-        getDependencies(resourceY, mockRouterStoreContext)(mockApi)
+        getDependencies(resourceY, mockRouterStoreContext, {})(mockApi)
       ).toThrow(
         new ResourceDependencyError(
           'Illegal dependency: "y" depends "x" so "x" must precede "y"'

--- a/src/__tests__/unit/controllers/resource-store/utils/lru-cache/test.ts
+++ b/src/__tests__/unit/controllers/resource-store/utils/lru-cache/test.ts
@@ -1,7 +1,7 @@
 import { getLRUResourceKey } from '../../../../../../controllers/resource-store/utils/lru-cache';
 import {
   RouteResourceDataForType,
-  RouteResourceResponseBase,
+  RouteResourceResponse,
   RouteResourceTimestamp,
 } from '../../../../../../common/types';
 
@@ -13,7 +13,7 @@ const mock = <T>({
   data: T;
   accessedAt: RouteResourceTimestamp;
   expiresAt: RouteResourceTimestamp;
-}): RouteResourceResponseBase<T> => ({
+}): RouteResourceResponse<T> => ({
   loading: false,
   error: null,
   data,

--- a/src/__tests__/unit/controllers/router-store/test.tsx
+++ b/src/__tests__/unit/controllers/router-store/test.tsx
@@ -653,7 +653,7 @@ describe('SPA Router store', () => {
               return <div>{props.error}</div>;
             }
 
-            return <div>{props.data.toString()}</div>;
+            return <div>{props.data?.toString()}</div>;
           }}
         </ResourceSubscriber>
       );

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -119,7 +119,7 @@ export type RouteResourceAsyncResult<RouteResourceData> =
       promise: null;
     };
 
-export type RouteResourceResponseBase<RouteResourceData> = {
+type RouteResourceResponseBase<RouteResourceData> = {
   key?: string;
   loading: RouteResourceLoading;
   error: RouteResourceError | null;
@@ -127,6 +127,14 @@ export type RouteResourceResponseBase<RouteResourceData> = {
   promise: Promise<RouteResourceData> | null;
   expiresAt: RouteResourceTimestamp;
   accessedAt: RouteResourceTimestamp;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export type RouteResourceResponseInitial<RouteResourceData> = {
+  loading: false;
+  error: null;
+  data: null;
+  promise: null;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -149,6 +157,7 @@ export type RouteResourceResponseLoaded<RouteResourceData> = {
 export type RouteResourceResponse<RouteResourceData = unknown> =
   RouteResourceResponseBase<RouteResourceData> &
     (
+      | RouteResourceResponseInitial<RouteResourceData>
       | RouteResourceResponseLoading<RouteResourceData>
       | RouteResourceResponseError<RouteResourceData>
       | RouteResourceResponseLoaded<RouteResourceData>
@@ -190,13 +199,12 @@ export type RouteResources = RouteResource[];
 
 export interface ResourceStoreContext {}
 
-export type RouteResourceDataForType = {
-  [key: string]: RouteResourceResponseBase<unknown>;
-};
+export type RouteResourceDataForType = Record<
+  string,
+  RouteResourceResponse<unknown>
+>;
 
-export type ResourceStoreData = {
-  [type: string]: RouteResourceDataForType;
-};
+export type ResourceStoreData = Record<string, RouteResourceDataForType>;
 
 export type RouterContext = {
   route: Route;
@@ -205,7 +213,7 @@ export type RouterContext = {
 };
 
 export type ResourceDependencies = {
-  [type: string]: RouteResourceResponse;
+  [type: string]: RouteResourceResponse | undefined;
 };
 
 /**

--- a/src/controllers/resource-store/constants.ts
+++ b/src/controllers/resource-store/constants.ts
@@ -1,6 +1,7 @@
 export const DEFAULT_RESOURCE_MAX_AGE = 0;
 export const DEFAULT_CACHE_MAX_LIMIT = 100;
 export const DEFAULT_RESOURCE_BROWSER_ONLY = false;
+export const DEFAULT_PREFETCH_MAX_AGE = 10 * 1000;
 
 /**
  * The base defaults which should be fed into any factory that needs to derive other props.

--- a/src/controllers/resource-store/types.ts
+++ b/src/controllers/resource-store/types.ts
@@ -13,11 +13,17 @@ import {
 
 export type ExecutionTuple = [RouteResource, ResourceAction<any>];
 export type ExecutionMaybeTuple = [RouteResource, ResourceAction<any> | null];
+export type PrefetchSlice = {
+  promise: Promise<unknown>;
+  data: unknown;
+  expiresAt: number;
+};
 
 export type State = {
   data: ResourceStoreData;
   context: ResourceStoreContext;
   executing: ExecutionMaybeTuple[] | null;
+  prefetching: Record<string, Record<string, PrefetchSlice | undefined>> | null;
 };
 
 export type HydratableState = {
@@ -74,6 +80,11 @@ export type Actions = {
     routerStoreContext: RouterContext,
     options: GetResourceOptions
   ) => ResourceAction<Promise<RouteResourceResponse>[]>;
+  prefetchResources: (
+    resources: RouteResource[],
+    routerStoreContext: RouterContext,
+    options: GetResourceOptions
+  ) => ResourceAction<Promise<void>[]>;
   hydrate: (
     state: HydratableState
   ) => ({ getState, setState }: StoreActionApi<State>) => void;

--- a/src/controllers/resource-store/utils/create-loading-slice/index.tsx
+++ b/src/controllers/resource-store/utils/create-loading-slice/index.tsx
@@ -47,7 +47,11 @@ export function createLoadingSlice({
   // ensure the promise includes any timeout error
   const timeoutGuard = timeout ? generateTimeGuard(timeout) : null;
 
-  const data = promiseOrData instanceof Promise ? undefined : promiseOrData;
+  // check if getData was sync, by looking for a Promise-like shape
+  const data =
+    typeof (promiseOrData as any)?.then === 'function'
+      ? undefined
+      : promiseOrData;
   const promise = timeout
     ? Promise.race([promiseOrData, timeoutGuard?.promise]).then(maybeData => {
         if (timeoutGuard && !timeoutGuard.isPending) {

--- a/src/controllers/resource-store/utils/create-loading-slice/index.tsx
+++ b/src/controllers/resource-store/utils/create-loading-slice/index.tsx
@@ -1,0 +1,76 @@
+import {
+  ResourceDependencies,
+  ResourceStoreContext,
+  RouterContext,
+  RouteResource,
+} from '../../../../common/types';
+import {
+  DEFAULT_RESOURCE_MAX_AGE,
+  DEFAULT_PREFETCH_MAX_AGE,
+} from '../../constants';
+import { GetResourceOptions, PrefetchSlice } from '../../types';
+import { getExpiresAt } from '../expires-at';
+import { generateTimeGuard } from '../generate-time-guard';
+import { TimeoutError } from '../timeout-error';
+
+export function createLoadingSlice({
+  context,
+  dependencies,
+  options,
+  resource,
+  routerStoreContext,
+}: {
+  context: ResourceStoreContext;
+  dependencies: () => ResourceDependencies;
+  options: GetResourceOptions;
+  resource: RouteResource;
+  routerStoreContext: RouterContext;
+}): PrefetchSlice {
+  const { type, getData } = resource;
+  const { prefetch, timeout } = options;
+
+  // hard errors in dependencies or getData are converted into softer async error
+  let promiseOrData: unknown | Promise<unknown>;
+  try {
+    promiseOrData = getData(
+      {
+        ...routerStoreContext,
+        isPrefetch: !!prefetch,
+        dependencies: dependencies(),
+      },
+      context
+    );
+  } catch (error) {
+    promiseOrData = Promise.reject(error);
+  }
+
+  // ensure the promise includes any timeout error
+  const timeoutGuard = timeout ? generateTimeGuard(timeout) : null;
+
+  const data = promiseOrData instanceof Promise ? undefined : promiseOrData;
+  const promise = timeout
+    ? Promise.race([promiseOrData, timeoutGuard?.promise]).then(maybeData => {
+        if (timeoutGuard && !timeoutGuard.isPending) {
+          throw new TimeoutError(type);
+        }
+        timeoutGuard?.timerId && clearTimeout(timeoutGuard.timerId);
+
+        return maybeData;
+      })
+    : // if we already have a result, wrap it so consumers can access it via same API
+    data !== undefined
+    ? Promise.resolve(data)
+    : (promiseOrData as Promise<unknown>);
+
+  const resourceMaxAge = getExpiresAt(
+    resource.maxAge ?? DEFAULT_RESOURCE_MAX_AGE
+  );
+
+  return {
+    promise,
+    data,
+    expiresAt: prefetch
+      ? Math.max(resourceMaxAge, getExpiresAt(DEFAULT_PREFETCH_MAX_AGE))
+      : resourceMaxAge,
+  };
+}

--- a/src/controllers/resource-store/utils/index.ts
+++ b/src/controllers/resource-store/utils/index.ts
@@ -11,10 +11,13 @@ export { routeHasChanged, routeHasResources } from './route-checks';
 export { TimeoutError } from './timeout-error';
 export { setSsrDataPromise } from './ssr-data-promise';
 export { validateLRUCache } from './lru-cache';
+export { createLoadingSlice } from './create-loading-slice';
 export {
   deleteResourceState,
   getResourceState,
   setResourceState,
+  getPrefetchSlice,
+  setPrefetchSlice,
 } from './manage-resource-state';
 export {
   ResourceDependencyError,
@@ -23,4 +26,3 @@ export {
   executeForDependents,
   getDependencies,
 } from './dependent-resources';
-export { toPromise } from './to-promise';

--- a/src/controllers/resource-store/utils/manage-resource-state/index.ts
+++ b/src/controllers/resource-store/utils/manage-resource-state/index.ts
@@ -6,12 +6,46 @@ import {
   RouteResourceResponse,
 } from '../../../../common/types';
 
-import { State } from '../../types';
+import { PrefetchSlice, State } from '../../types';
+
+export const getPrefetchSlice =
+  (type: ResourceType, key: ResourceKey) =>
+  ({ getState }: StoreActionApi<State>) => {
+    const { prefetching } = getState();
+    const slice = prefetching?.[type]?.[key];
+
+    // check if slice is still fresh
+    if (slice && Date.now() < Number(slice.expiresAt)) {
+      return slice;
+    }
+
+    return undefined;
+  };
+
+export const setPrefetchSlice =
+  (type: ResourceType, key: ResourceKey, slice: PrefetchSlice | undefined) =>
+  ({ setState, getState }: StoreActionApi<State>) => {
+    const { prefetching } = getState();
+    // avoid doing extra set if same value
+    if (prefetching?.[type]?.[key] === slice) return;
+
+    // cheap optimisation to provide prefetched result syncronously
+    slice?.promise?.then(maybeData => (slice.data = maybeData));
+
+    setState({
+      prefetching: {
+        ...prefetching,
+        [type]: { ...prefetching?.[type], [key]: slice },
+      },
+    });
+  };
 
 export const setResourceState =
   (type: ResourceType, key: ResourceKey, state: RouteResourceResponse) =>
-  ({ setState, getState }: StoreActionApi<State>) => {
+  ({ setState, getState, dispatch }: StoreActionApi<State>) => {
     const { data } = getState();
+    // every time we override a resource we kill its prefetched
+    dispatch(setPrefetchSlice(type, key, undefined));
 
     setState({
       data: {

--- a/src/controllers/resource-store/utils/to-promise/index.ts
+++ b/src/controllers/resource-store/utils/to-promise/index.ts
@@ -1,2 +1,0 @@
-export const toPromise = <T>(candidate: T | Promise<T>): Promise<T> =>
-  candidate instanceof Promise ? candidate : Promise.resolve(candidate);

--- a/src/controllers/resource-store/utils/transform-data/index.ts
+++ b/src/controllers/resource-store/utils/transform-data/index.ts
@@ -1,13 +1,13 @@
 import {
   ResourceStoreData,
-  RouteResourceResponseBase,
+  RouteResourceResponse,
 } from '../../../../common/types';
 
 export const transformData = (
   data: ResourceStoreData,
   transformer: (
-    slice: RouteResourceResponseBase<unknown>
-  ) => RouteResourceResponseBase<unknown>
+    slice: RouteResourceResponse<unknown>
+  ) => RouteResourceResponse<unknown>
 ) =>
   Object.keys(data).reduce((acc: ResourceStoreData, type: string) => {
     if (!acc[type]) {

--- a/src/controllers/router-store/index.tsx
+++ b/src/controllers/router-store/index.tsx
@@ -149,11 +149,8 @@ const actions: AllRouterActions = {
     (path, nextContext) =>
     ({ getState }) => {
       const { routes, basePath, onPrefetch, route, match, query } = getState();
-      const {
-        cleanExpiredResources,
-        requestResources,
-        getContext: getResourceStoreContext,
-      } = getResourceStore().actions;
+      const { prefetchResources, getContext: getResourceStoreContext } =
+        getResourceStore().actions;
 
       if (!nextContext && !isExternalAbsolutePath(path)) {
         const location = parsePath(getRelativePath(path, basePath) as any);
@@ -170,10 +167,7 @@ const actions: AllRouterActions = {
       );
 
       batch(() => {
-        cleanExpiredResources(nextResources, nextLocationContext);
-        requestResources(nextResources, nextLocationContext, {
-          prefetch: true,
-        });
+        prefetchResources(nextResources, nextLocationContext, {});
         if (onPrefetch) onPrefetch(nextLocationContext);
       });
     },


### PR DESCRIPTION
Current prefetch updates resources values directly, making them change state (eg going back to loading) if they are expired. That is problematic as might make current page blink if an expired resource is shared between current route and prefetched route. The solution is storing prefetched slices in a secondary map, and consuming them if available when the action (eg navigation) is confirmed.

Fixes #176 