### PR TITLE
Refactor router store tests

### DIFF
--- a/src/controllers/router-store/test.tsx
+++ b/src/controllers/router-store/test.tsx
@@ -1,897 +1,389 @@
-import { mount, render } from 'enzyme';
-import * as historyHelper from 'history';
-import * as historyHelper5 from 'history-5';
+import { mount } from 'enzyme';
+import * as history4 from 'history';
+import * as history5 from 'history-5';
 import React from 'react';
-import { act } from 'react-dom/test-utils';
-import { createSubscriber, defaultRegistry } from 'react-sweet-state';
+import { defaultRegistry } from 'react-sweet-state';
 
-import { DEFAULT_ACTION } from '../../common/constants';
-import { mockRoute } from '../../common/mocks';
-import { MemoryRouter as Router } from '../memory-router';
-import { createResource, getResourceStore } from '../resource-store';
-import { ResourceSubscriber } from '../resource-subscriber';
+import { getResourceStore } from '../resource-store';
 
-import { AllRouterActions, EntireRouterState } from './types';
+import { ContainerProps } from './types';
 
 import {
   createRouterSelector,
   getRouterState,
   getRouterStore,
   INITIAL_STATE,
-  RouterStore,
+  RouterContainer,
 } from './index';
 
-const mockLocation = {
-  pathname: '/pathname',
-  search: '?foo=bar',
-  hash: '#hash',
-};
+describe('RouterStore', () => {
+  describe.each([
+    ['v4', history4],
+    ['v5', history5],
+  ])('with history %s', (_, historyApi) => {
+    const { createMemoryHistory } = historyApi;
+    const location = {
+      pathname: '/pages',
+      search: '?key=value',
+      hash: '#hash',
+    };
 
-const mockHistory = {
-  push: jest.fn(),
-  replace: jest.fn(),
-  goBack: jest.fn(),
-  goForward: jest.fn(),
-  registerBlock: jest.fn(),
-  listen: jest.fn(),
-  createHref: jest.fn(),
-  location: mockLocation,
-  block: jest.fn(),
-};
+    const routes = [
+      {
+        path: '/pages',
+        component: () => <div>pages</div>,
+        exact: true,
+        name: 'pages',
+      },
+      {
+        path: '/pages/:id',
+        component: () => <div>page</div>,
+        name: 'page',
+      },
+    ];
 
-const mockRoutes = [
-  {
-    path: '/pathname',
-    component: () => <div>path</div>,
-    name: '',
-  },
-  {
-    path: '/blah',
-    component: () => <div>path</div>,
-    name: '',
-  },
-];
+    function renderRouterContainer(props: Partial<ContainerProps> = {}) {
+      const history = createMemoryHistory({ initialEntries: [location] });
+      const listen = jest.spyOn(history, 'listen');
+      const push = jest.spyOn(history, 'push');
+      const replace = jest.spyOn(history, 'replace');
 
-const RouterStoreSubscriber = createSubscriber<
-  EntireRouterState,
-  AllRouterActions
->(RouterStore, {
-  displayName: 'RouterStoreSubscriber',
-});
-
-const nextTick = () => new Promise(resolve => setTimeout(resolve));
-
-describe('SPA Router store', () => {
-  const { location } = window;
-
-  beforeAll(() => {
-    // @ts-ignore
-    delete window.location;
-    // @ts-ignore
-    window.location = {};
-    Object.defineProperties(window.location, {
-      href: { value: location.href },
-      assign: { value: jest.fn() },
-      replace: { value: jest.fn() },
-    });
-  });
-
-  afterEach(() => {
-    defaultRegistry.stores.clear();
-    jest.resetAllMocks();
-    jest.restoreAllMocks();
-  });
-
-  afterAll(() => {
-    window.location = location;
-  });
-
-  describe('initialising the store', () => {
-    beforeEach(() => {
-      jest
-        .spyOn(historyHelper, 'createMemoryHistory')
-        // @ts-ignore
-        .mockImplementation(() => mockHistory);
-    });
-
-    it('should call the history listener when initialised', () => {
-      mount(<Router routes={[]} />);
-
-      expect(mockHistory.listen).toBeCalled();
-    });
-
-    it('should send right props after render with routes', () => {
       mount(
-        <Router routes={[mockRoutes[0]]}>
-          <RouterStoreSubscriber>
-            {({
-              history,
-              location: currentLocation,
-              routes,
-              route,
-              match,
-              query,
-            }) => {
-              expect(history).toEqual(mockHistory);
-              expect(currentLocation).toEqual(mockLocation);
-              expect(routes).toEqual(routes);
-              expect(route).toEqual(
-                expect.objectContaining({
-                  path: `/pathname`,
-                })
-              );
-              expect(match).toBeTruthy();
-              expect(query).toEqual({
-                foo: 'bar',
-              });
-
-              return <div>I am a subscriber</div>;
-            }}
-          </RouterStoreSubscriber>
-        </Router>
+        <RouterContainer
+          history={history}
+          isGlobal
+          routes={routes}
+          {...props}
+        />
       );
-    });
 
-    it('should use default store values if no overrides are provided', () => {
-      expect.assertions(1);
-
-      render(
-        <RouterStoreSubscriber>
-          {renderProps => {
-            expect(renderProps).toEqual(
-              expect.objectContaining({
-                ...INITIAL_STATE,
-                history: expect.objectContaining({
-                  push: expect.any(Function),
-                  replace: expect.any(Function),
-                  goBack: expect.any(Function),
-                  goForward: expect.any(Function),
-                  listen: expect.any(Function),
-                  block: expect.any(Function),
-                  createHref: expect.any(Function),
-                }),
-              })
-            );
-
-            return <div>I am a lonely subscriber</div>;
-          }}
-        </RouterStoreSubscriber>
-      );
-    });
-  });
-
-  describe('listening for real history changes on history@4', () => {
-    let children: any;
-
-    beforeEach(() => {
-      children = jest.fn().mockReturnValue(null);
-    });
-
-    it('should send location with route change', async () => {
-      mount(
-        <Router routes={mockRoutes} location={mockRoutes[0].path}>
-          <RouterStoreSubscriber>{children}</RouterStoreSubscriber>
-        </Router>
-      );
-      const { history } = children.mock.calls[0][0];
-
-      await nextTick();
-
-      expect(children.mock.calls[0]).toEqual([
-        expect.objectContaining({
-          routes: mockRoutes,
-          route: mockRoutes[0],
-          action: DEFAULT_ACTION,
-          history: expect.any(Object),
+      return {
+        actions: getRouterStore().actions,
+        getState: getRouterState,
+        history: Object.assign({}, history, {
+          listen,
+          push,
+          replace,
         }),
-        expect.any(Object),
-      ]);
-
-      const newLocation = {
-        pathname: '/blah',
-        search: '?somequery=value',
-        hash: '#bing',
       };
-
-      history.push(Object.values(newLocation).join(''));
-
-      await nextTick();
-
-      expect(children.mock.calls[1]).toEqual([
-        expect.objectContaining({
-          routes: mockRoutes,
-          route: mockRoutes[1],
-          action: 'PUSH',
-          history: expect.any(Object),
-        }),
-        expect.any(Object),
-      ]);
-    });
-
-    it('should send correct action key for route changes', async () => {
-      mount(
-        <Router routes={mockRoutes}>
-          <RouterStoreSubscriber>{children}</RouterStoreSubscriber>
-        </Router>
-      );
-      const { history } = children.mock.calls[0][0];
-
-      expect(children.mock.calls[0]).toEqual([
-        expect.objectContaining({
-          action: DEFAULT_ACTION,
-        }),
-        expect.any(Object),
-      ]);
-
-      history.push('/pathname');
-
-      await nextTick();
-
-      expect(children.mock.calls[1]).toEqual([
-        expect.objectContaining({
-          action: 'PUSH',
-        }),
-        expect.any(Object),
-      ]);
-
-      history.replace('/blah');
-
-      await nextTick();
-
-      expect(children.mock.calls[2]).toEqual([
-        expect.objectContaining({
-          action: 'REPLACE',
-        }),
-        expect.any(Object),
-      ]);
-    });
-  });
-
-  describe('listening for real history changes on history@5', () => {
-    let children: any;
+    }
 
     beforeEach(() => {
-      children = jest.fn().mockReturnValue(null);
-
-      jest
-        .spyOn(historyHelper, 'createMemoryHistory')
-        // @ts-ignore
-        .mockImplementation(historyHelper5.createMemoryHistory);
+      Object.defineProperty(window, 'location', {
+        value: {
+          assign: jest.fn(),
+          href: 'http://localhost:3000',
+          replace: jest.fn(),
+        },
+      });
     });
 
-    it('should send location with route change', async () => {
-      mount(
-        <Router routes={mockRoutes} location={mockRoutes[0].path}>
-          <RouterStoreSubscriber>{children}</RouterStoreSubscriber>
-        </Router>
-      );
-      const { history } = children.mock.calls[0][0];
-
-      await nextTick();
-
-      expect(children.mock.calls[0]).toEqual([
-        expect.objectContaining({
-          routes: mockRoutes,
-          route: mockRoutes[0],
-          action: DEFAULT_ACTION,
-          history: expect.any(Object),
-        }),
-        expect.any(Object),
-      ]);
-
-      const newLocation = {
-        pathname: '/blah',
-        search: '?somequery=value',
-        hash: '#bing',
-      };
-
-      history.push(Object.values(newLocation).join(''));
-
-      await nextTick();
-
-      expect(children.mock.calls[1]).toEqual([
-        expect.objectContaining({
-          routes: mockRoutes,
-          route: mockRoutes[1],
-          action: 'PUSH',
-          history: expect.any(Object),
-        }),
-        expect.any(Object),
-      ]);
+    afterEach(() => {
+      defaultRegistry.stores.clear();
+      jest.restoreAllMocks();
     });
 
-    it('should send correct action key for route changes', async () => {
-      mount(
-        <Router routes={mockRoutes}>
-          <RouterStoreSubscriber>{children}</RouterStoreSubscriber>
-        </Router>
-      );
-      const { history } = children.mock.calls[0][0];
-
-      expect(children.mock.calls[0]).toEqual([
-        expect.objectContaining({
-          action: DEFAULT_ACTION,
+    it('returns the default state when the container is not initialised', () => {
+      expect(getRouterState()).toEqual({
+        ...INITIAL_STATE,
+        history: expect.objectContaining({
+          block: expect.any(Function),
+          createHref: expect.any(Function),
+          goBack: expect.any(Function),
+          goForward: expect.any(Function),
+          listen: expect.any(Function),
+          push: expect.any(Function),
+          replace: expect.any(Function),
         }),
-        expect.any(Object),
-      ]);
-
-      history.push('/pathname');
-
-      await nextTick();
-
-      expect(children.mock.calls[1]).toEqual([
-        expect.objectContaining({
-          action: 'PUSH',
-        }),
-        expect.any(Object),
-      ]);
-
-      history.replace('/blah');
-
-      await nextTick();
-
-      expect(children.mock.calls[2]).toEqual([
-        expect.objectContaining({
-          action: 'REPLACE',
-        }),
-        expect.any(Object),
-      ]);
-    });
-  });
-
-  describe('store actions', () => {
-    const currentLocation = 'http://localhost/';
-
-    beforeEach(() => {
-      jest
-        .spyOn(historyHelper, 'createMemoryHistory')
-        // @ts-ignore
-        .mockImplementation(() => mockHistory);
+      });
     });
 
-    describe('push()', () => {
-      it('should push a relative path if the URL is absolute but on the same domain', () => {
-        const path = 'http://localhost:3000/board/123';
-        const { actions } = getRouterStore();
+    describe('when the container is rendered', () => {
+      it('calls history.listen()', () => {
+        const { history } = renderRouterContainer();
 
-        mount(<Router routes={[]} />);
-
-        actions.push(path);
-
-        // expect(window.location.href).toEqual(currentLocation);
-        expect(mockHistory.push).toBeCalledWith('/board/123');
+        expect(history.listen).toHaveBeenCalledTimes(1);
       });
 
-      it('should push a relative path a Location object is pushed', () => {
-        const { actions } = getRouterStore();
+      it('returns the expected state', () => {
+        const onPrefetch = jest.fn();
+        const { history, getState } = renderRouterContainer({ onPrefetch });
 
-        mount(<Router routes={[]} />);
-
-        actions.push({ pathname: '/board/123', search: '', hash: '' });
-
-        expect(mockHistory.push).toBeCalledWith({
-          pathname: '/board/123',
-          search: '',
-          hash: '',
+        expect(getState()).toMatchObject({
+          ...INITIAL_STATE,
+          history,
+          location,
+          match: {
+            isExact: true,
+            params: expect.any(Object),
+            path: location.pathname,
+            query: expect.any(Object),
+            url: location.pathname,
+          },
+          onPrefetch,
+          query: {
+            key: 'value',
+          },
+          route: routes[0],
+          routes: routes,
+          unlisten: expect.any(Function),
         });
       });
 
-      it('should call window.location.assign with the absolute URL if it is on a different domain', () => {
-        const path = 'http://example.com';
-        const { actions } = getRouterStore();
+      it('hydrates the resource store with the provided data', () => {
+        const hydrate = jest.spyOn(getResourceStore().actions, 'hydrate');
+        const resourceContext = { context: 'test' };
+        const resourceData = {
+          type: {
+            key: {
+              accessedAt: 0,
+              data: 'data',
+              error: null,
+              expiresAt: 0,
+              loading: false,
+              promise: Promise.resolve('data'),
+            },
+          },
+        };
 
-        jest
-          .spyOn(window.location, 'assign')
-          .mockImplementation(() => jest.fn());
+        renderRouterContainer({
+          resourceContext,
+          resourceData,
+        });
 
-        mount(<Router routes={[]} />);
+        expect(hydrate).toBeCalledWith({
+          resourceContext,
+          resourceData,
+        });
+      });
 
-        actions.push(path);
+      it('requests route resources', () => {
+        const requestAllResources = jest.spyOn(
+          getResourceStore().actions,
+          'requestAllResources'
+        );
 
-        expect(window.location.href).toEqual(currentLocation);
-        expect(window.location.assign).toBeCalledWith(path);
+        const { getState } = renderRouterContainer();
+
+        const { route, match, query } = getState();
+
+        expect(requestAllResources).toBeCalledTimes(1);
+        expect(requestAllResources).toBeCalledWith(
+          {
+            route,
+            match,
+            query,
+          },
+          {
+            timeout: undefined,
+          }
+        );
+      });
+    });
+
+    describe('push()', () => {
+      describe.each([undefined, '/base-path'])('with %s basePath', basePath => {
+        it('pushes a relative path given a relative path', async () => {
+          const { actions, getState, history } = renderRouterContainer({
+            basePath,
+          });
+
+          actions.push('/pages/1');
+
+          expect(history.push).toBeCalledWith(`${basePath ?? ''}/pages/1`);
+          expect(getState()).toMatchObject({
+            action: 'PUSH',
+            route: routes[1],
+          });
+        });
+
+        if (!basePath) {
+          it('pushes a relative path given an absolute URL on the same domain', async () => {
+            const { actions, getState, history } = renderRouterContainer();
+
+            actions.push(`http://localhost:3000${basePath ?? ''}/pages/1`);
+
+            expect(history.push).toBeCalledWith(`${basePath ?? ''}/pages/1`);
+            expect(getState()).toMatchObject({
+              action: 'PUSH',
+              route: routes[1],
+            });
+          });
+
+          it('pushes a relative path given an absolute URL on the same domain', async () => {
+            const { actions, getState, history } = renderRouterContainer();
+
+            actions.push(`http://localhost:3000/pages/1`);
+
+            expect(history.push).toBeCalledWith('/pages/1');
+            expect(getState()).toMatchObject({
+              action: 'PUSH',
+              route: routes[1],
+            });
+          });
+
+          it('pushes a relative Location object given a relative Location object', async () => {
+            const { actions, getState, history } = renderRouterContainer();
+            const nextLocation = { pathname: '/pages/1', search: '', hash: '' };
+
+            actions.push(nextLocation);
+
+            expect(history.push).toBeCalledWith(nextLocation);
+            expect(getState()).toMatchObject({
+              action: 'PUSH',
+              route: routes[1],
+            });
+          });
+        }
+      });
+
+      it('calls location.assign given an absolute URL on a different domain', () => {
+        const assign = jest.spyOn(window.location, 'assign');
+        const { actions } = renderRouterContainer();
+
+        actions.push('http://example.com');
+
+        expect(assign).toBeCalledWith('http://example.com');
       });
     });
 
     describe('pushTo()', () => {
-      it('should push a relative path generated from route and parameters', () => {
-        const route = { name: '', path: '/page/:id', component: () => null };
-        const { actions } = getRouterStore();
-
-        mount(<Router routes={[]} />);
+      it('pushes a relative path generated from the route and parameters', () => {
+        const route = routes[1];
+        const { actions, getState, history } = renderRouterContainer();
 
         actions.pushTo(route, { params: { id: '1' }, query: { uid: '1' } });
 
-        expect(mockHistory.push).toBeCalledWith({
+        expect(history.push).toBeCalledWith({
           hash: '',
-          pathname: '/page/1',
+          pathname: '/pages/1',
           search: '?uid=1',
+        });
+
+        expect(getState()).toMatchObject({
+          action: 'PUSH',
+          route,
         });
       });
     });
 
     describe('replace()', () => {
-      it('should replace a relative path if the URL is absolute but on the same domain', () => {
-        const path = 'http://localhost:3000/board/123';
-        const { actions } = getRouterStore();
+      describe.each([undefined, '/base-path'])('with %s basePath', basePath => {
+        it('replaces a relative path given a relative path', async () => {
+          const { actions, getState, history } = renderRouterContainer({
+            basePath,
+          });
 
-        mount(<Router routes={[]} />);
+          actions.replace('/pages/1');
 
-        actions.replace(path);
-
-        expect(window.location.href).toEqual(currentLocation);
-        expect(mockHistory.replace).toBeCalledWith('/board/123');
+          expect(history.replace).toBeCalledWith(`${basePath ?? ''}/pages/1`);
+          expect(getState()).toMatchObject({
+            action: 'REPLACE',
+            route: routes[1],
+          });
+        });
       });
 
-      it('should call window.location.replace with the absolute URL if it is on a different domain', () => {
-        const path = 'http://example.com';
-        const { actions } = getRouterStore();
-
-        jest
-          .spyOn(window.location, 'replace')
-          .mockImplementation(() => jest.fn());
-
-        mount(<Router routes={[]} />);
+      it('replaces an absolute URL on the same domain with a relative path', () => {
+        const path = 'http://localhost:3000/pages/1';
+        const { actions, getState, history } = renderRouterContainer();
 
         actions.replace(path);
 
-        expect(window.location.href).toEqual(currentLocation);
-        expect(window.location.replace).toBeCalledWith(path);
+        expect(history.replace).toBeCalledWith('/pages/1');
+        expect(getState()).toMatchObject({
+          action: 'REPLACE',
+          route: routes[1],
+        });
+      });
+
+      it('calls window.location.replace with an absolute URL on a different domain', () => {
+        const replace = jest.spyOn(window.location, 'replace');
+        const { actions } = renderRouterContainer();
+
+        actions.replace('http://example.com');
+
+        expect(replace).toBeCalledWith('http://example.com');
       });
     });
 
     describe('replaceTo()', () => {
-      it('should replace a relative path generated from route and parameters', () => {
-        const route = { name: '', path: '/page/:id', component: () => null };
-        const { actions } = getRouterStore();
-
-        mount(<Router routes={[]} />);
+      it('replaces a route and parameters with a relative path', () => {
+        const route = routes[1];
+        const { actions, getState, history } = renderRouterContainer();
 
         actions.replaceTo(route, { params: { id: '1' }, query: { uid: '1' } });
 
-        expect(mockHistory.replace).toBeCalledWith({
+        expect(history.replace).toBeCalledWith({
           hash: '',
-          pathname: '/page/1',
+          pathname: '/pages/1',
           search: '?uid=1',
+        });
+
+        expect(getState()).toMatchObject({
+          action: 'REPLACE',
+          route,
         });
       });
     });
-  });
 
-  describe('resource store interop', () => {
-    const containerProps = {
-      isStatic: false,
-      history: mockHistory,
-      routes: [],
-      resourceContext: {},
-      resourceData: {},
-    };
+    describe('createRouterSelector()', () => {
+      it('should return selected state', () => {
+        const routeNameSelector = jest
+          .fn()
+          .mockImplementation(s => s.route.name);
 
-    beforeEach(() => {
-      jest.clearAllMocks();
-    });
+        const useRouteName = createRouterSelector(routeNameSelector);
+        const RouteName = () => <>{useRouteName()}</>;
 
-    it('should hydrate the resource store state when bootstrapped', () => {
-      const resourceContext = { foo: 'bar' };
-      const resourceData = {};
-      const initialResourceStoreState = {
-        resourceContext,
-        resourceData,
-      };
-      const props = { ...containerProps, ...initialResourceStoreState };
-      const hydrate = jest.spyOn(getResourceStore().actions, 'hydrate');
+        const route = {
+          component: () => null,
+          name: 'home',
+          path: '',
+        };
 
-      // @ts-ignore - mocks
-      getRouterStore().actions.bootstrapStore(props);
+        const wrapper = mount(
+          <RouterContainer history={createMemoryHistory()} routes={[route]}>
+            <RouteName />
+          </RouterContainer>
+        );
 
-      expect(hydrate).toBeCalledWith({
-        resourceContext,
-        resourceData,
+        expect(routeNameSelector).toBeCalledWith(
+          expect.objectContaining({ route }),
+          undefined
+        );
+        expect(wrapper.html()).toEqual('home');
       });
-    });
 
-    it('should request route resources when the router is mounted', () => {
-      const requestAllResources = jest.spyOn(
-        getResourceStore().actions,
-        'requestAllResources'
-      );
-
-      mount(<Router routes={mockRoutes} />);
-
-      const { route, match, query } = getRouterState();
-
-      expect(requestAllResources).toBeCalledTimes(1);
-      expect(requestAllResources).toBeCalledWith(
-        {
-          route,
-          match,
-          query,
-        },
-        {
-          timeout: undefined,
-        }
-      );
-    });
-  });
-
-  describe('history listen resource store interop', () => {
-    const getResourceStoreStateData = () =>
-      getResourceStore().storeState.getState().data;
-    const componentRenderSpy = jest.fn();
-
-    let componentRenderStates: string[] = [];
-
-    beforeEach(() => {
-      componentRenderSpy.mockImplementation(arg =>
-        componentRenderStates.push(arg)
-      );
-    });
-
-    afterEach(() => {
-      defaultRegistry.stores.clear();
-      componentRenderStates = [];
-    });
-
-    const mountAppSetInitialLocationAndGetHistoryPush = async (
-      routes: any[],
-      initialLocation: string
-    ): Promise<any> => {
-      let historyPush = (path: string) => {
-        path;
-      };
-
-      mount(
-        <Router routes={routes} location={initialLocation}>
-          <RouterStoreSubscriber>
-            {(
-              { route, location: currentLocation, query, match, action },
-              { push }
-            ) => {
-              historyPush = push;
-
-              return !route ? null : (
-                <route.component
-                  route={route}
-                  location={currentLocation}
-                  query={query}
-                  match={match}
-                  action={action}
-                />
-              );
-            }}
-          </RouterStoreSubscriber>
-        </Router>
-      );
-
-      await nextTick();
-
-      return historyPush;
-    };
-
-    const resourceA = createResource({
-      type: 'TYPE_A',
-      getKey: () => 'KEY_A',
-      getData: () => Promise.resolve(`A-${Date.now()}`),
-      maxAge: 0,
-    });
-
-    const resourceB = createResource({
-      type: 'TYPE_B',
-      getKey: () => 'KEY_B',
-      getData: () => Promise.resolve(`B-${Date.now()}`),
-      maxAge: Infinity,
-    });
-
-    it('should transition between routes and not render components with stale data', async () => {
-      const ComponentA = () => (
-        <ResourceSubscriber resource={resourceA}>
-          {({ data, loading }) => {
-            if (loading) {
-              return <div>{componentRenderSpy(`loading:A`)}</div>;
-            }
-
-            return <div>{componentRenderSpy(`data:${String(data)}`)}</div>;
-          }}
-        </ResourceSubscriber>
-      );
-
-      const ComponentB = () => (
-        <ResourceSubscriber resource={resourceB}>
-          {props => {
-            if (props.loading) {
-              return <div>{props.loading}</div>;
-            }
-            if (props.error) {
-              return <div>{props.error}</div>;
-            }
-
-            return <div>{props.data?.toString()}</div>;
-          }}
-        </ResourceSubscriber>
-      );
-
-      const routes = [
-        {
-          ...mockRoute,
-          path: '/foo/a',
-          component: ComponentA,
-          resources: [resourceA],
-        },
-        {
-          ...mockRoute,
-          path: '/foo/b',
-          component: ComponentB,
-          resources: [resourceB],
-        },
-      ];
-
-      jest.spyOn(global.Date, 'now').mockReturnValue(100);
-
-      // We start at route fooA
-      const historyPush = await mountAppSetInitialLocationAndGetHistoryPush(
-        routes,
-        routes[0].path
-      );
-
-      const { data: dataA1 } = getResourceStoreStateData().TYPE_A.KEY_A;
-
-      jest.spyOn(global.Date, 'now').mockReturnValue(150);
-
-      // We go to route fooB
-      historyPush(routes[1].path);
-
-      await nextTick();
-      jest.spyOn(global.Date, 'now').mockReturnValue(200);
-
-      // We go back to fooA
-      historyPush(routes[0].path);
-
-      await nextTick();
-
-      const { data: dataA2 } = getResourceStoreStateData().TYPE_A.KEY_A;
-
-      expect(dataA1 === dataA2).toBeFalsy();
-      expect(componentRenderStates).toEqual([
-        'loading:A',
-        `data:${dataA1}`,
-        'loading:A',
-        `data:${dataA2}`,
-      ]);
-    });
-
-    it('should always get new data when doing full route changes and resources have expired', async () => {
-      const ComponentA = () => (
-        <ResourceSubscriber resource={resourceA}>
-          {({ data, loading }) => {
-            if (loading) {
-              return <div>{componentRenderSpy(`loading:A`)}</div>;
-            }
-
-            let message = '';
-
-            if (data === null) {
-              message = 'isNullAndCleanedByTransitionOutOfA';
-            } else {
-              message = String(data);
-            }
-
-            return <div>{componentRenderSpy(`data:${message}`)}</div>;
-          }}
-        </ResourceSubscriber>
-      );
-      const ComponentB = () => (
-        <ResourceSubscriber resource={resourceA}>
-          {({ data, loading }) => {
-            if (loading) {
-              return <div>{componentRenderSpy(`loading:B`)}</div>;
-            }
-
-            let message = '';
-
-            if (data === null) {
-              message = 'isNullAndCleanedByTransitionIntoB';
-            } else {
-              message = String(data);
-            }
-
-            return <div>{componentRenderSpy(`data:${message}`)}</div>;
-          }}
-        </ResourceSubscriber>
-      );
-      const routes = [
-        {
-          ...mockRoute,
-          path: '/foo/a',
-          component: ComponentA,
-          resources: [resourceA, resourceB],
-        },
-        {
-          ...mockRoute,
-          name: 'bar',
-          path: '/bar/a',
-          component: ComponentB,
-          resources: [resourceA, resourceB],
-        },
-      ];
-
-      jest.spyOn(global.Date, 'now').mockReturnValue(100);
-
-      // We start at route fooA
-      const historyPush = await mountAppSetInitialLocationAndGetHistoryPush(
-        routes,
-        routes[0].path
-      );
-      const { data: dataA1 } = getResourceStoreStateData().TYPE_A.KEY_A;
-
-      jest.spyOn(global.Date, 'now').mockReturnValue(150);
-
-      // We go to routeB
-      act(() => historyPush(routes[1].path));
-
-      await nextTick();
-
-      const { data: dataA2 } = getResourceStoreStateData().TYPE_A.KEY_A;
-
-      expect(dataA1 === dataA2).toBeFalsy();
-      expect(componentRenderStates).toEqual([
-        'loading:A',
-        `data:${dataA1}`,
-        // re-render
-        `data:${dataA1}`,
-        'loading:B',
-        `data:${dataA2}`,
-      ]);
-    });
-
-    it('should not clean resources when transitioning to the same route and keys have not changed', async () => {
-      const ComponentA = () => (
-        <ResourceSubscriber resource={resourceA}>
-          {({ data, loading }) => {
-            if (loading) {
-              return <div>{componentRenderSpy(`loading:A`)}</div>;
-            }
-
-            let message = '';
-
-            if (data === null) {
-              message = 'isNullAndCleanedByTransitionIntoB';
-            } else {
-              message = String(data);
-            }
-
-            return <div>{componentRenderSpy(`data:${message}`)}</div>;
-          }}
-        </ResourceSubscriber>
-      );
-      const routes = [
-        {
-          ...mockRoute,
-          path: '/foo/a',
-          component: ComponentA,
-          resources: [resourceA],
-        },
-      ];
-
-      jest.spyOn(global.Date, 'now').mockReturnValue(100);
-
-      // We start at route fooA
-      const historyPush = await mountAppSetInitialLocationAndGetHistoryPush(
-        routes,
-        routes[0].path
-      );
-
-      const { data: dataA1 } = getResourceStoreStateData().TYPE_A.KEY_A;
-
-      jest.spyOn(global.Date, 'now').mockReturnValue(150);
-
-      historyPush(`${routes[0].path}?blah`);
-
-      await nextTick();
-
-      // This means the resource was never cleaned
-      expect(
-        componentRenderStates.includes('data:isNullAndCleanedByTransitionIntoB')
-      ).toBeFalsy();
-      expect(componentRenderStates).toEqual([
-        'loading:A',
-        `data:${dataA1}`,
-        `data:${dataA1}`,
-      ]);
-    });
-
-    it('should not refresh cached resources when transitioning on the same route', async () => {
-      const ComponentB = () => (
-        <ResourceSubscriber resource={resourceB}>
-          {({ data, loading }) => {
-            if (loading) {
-              return <div>{componentRenderSpy(`loading:B`)}</div>;
-            }
-
-            let message = '';
-
-            if (data === null) {
-              message = 'isNullAndCleanedByTransitionIntoB';
-            } else {
-              message = String(data);
-            }
-
-            return <div>{componentRenderSpy(`data:${message}`)}</div>;
-          }}
-        </ResourceSubscriber>
-      );
-
-      const routes = [
-        {
-          ...mockRoute,
-          path: '/bar/:key',
-          component: ComponentB,
-          resources: [resourceA, resourceB],
-        },
-      ];
-
-      jest.spyOn(global.Date, 'now').mockReturnValue(100);
-
-      // We start at route fooA
-      const historyPush = await mountAppSetInitialLocationAndGetHistoryPush(
-        routes,
-        '/bar/first-key'
-      );
-
-      const { data: dataA1 } = getResourceStoreStateData().TYPE_B.KEY_B;
-
-      jest.spyOn(global.Date, 'now').mockReturnValue(150);
-
-      // We go to routeB
-      historyPush('/bar/second-key');
-
-      await nextTick();
-
-      const { data: dataA2 } = getResourceStoreStateData().TYPE_B.KEY_B;
-
-      expect(dataA1 === dataA2).toBeTruthy();
-      expect(componentRenderStates.includes('data:null')).toBeFalsy();
-    });
-  });
-
-  describe('createRouterSelector()', () => {
-    it('should return selected state', () => {
-      const mockSelector = jest.fn().mockImplementation(s => s.route.name);
-      const useRouteName = createRouterSelector(mockSelector);
-      const RouteName = () => <>{useRouteName()}</>;
-      const route = { path: '', name: 'home', component: () => null };
-
-      const wrapper = mount(
-        <Router routes={[route]}>
-          <RouteName />
-        </Router>
-      );
-
-      expect(mockSelector).toBeCalledWith(
-        expect.objectContaining({ route }),
-        undefined
-      );
-      expect(wrapper.html()).toEqual('home');
-    });
-
-    it('should pass through single hook argument to selector', () => {
-      const mockSelector = jest.fn().mockImplementation(s => s.route.name);
-      const useRouteName = createRouterSelector(mockSelector);
-      const RouteName = ({ argument }: { argument: unknown }) => (
-        <>{useRouteName(argument)}</>
-      );
-      const route = { path: '', name: 'home', component: () => null };
-
-      const wrapper = mount(
-        <Router routes={[route]}>
-          <RouteName argument="bar" />
-        </Router>
-      );
-
-      expect(mockSelector).toBeCalledWith(
-        expect.objectContaining({ route }),
-        'bar'
-      );
-      expect(wrapper.html()).toEqual('home');
+      it('should pass through single hook argument to selector', () => {
+        const routeNameSelector = jest
+          .fn()
+          .mockImplementation(s => s.route.name);
+
+        const useRouteName = createRouterSelector(routeNameSelector);
+
+        const RouteName = ({ argument }: { argument: unknown }) => (
+          <>{useRouteName(argument)}</>
+        );
+
+        const route = {
+          component: () => null,
+          name: 'home',
+          path: '',
+        };
+
+        const wrapper = mount(
+          <RouterContainer history={createMemoryHistory()} routes={[route]}>
+            <RouteName argument="bar" />
+          </RouterContainer>
+        );
+
+        expect(routeNameSelector).toBeCalledWith(
+          expect.objectContaining({ route }),
+          'bar'
+        );
+        expect(wrapper.html()).toEqual('home');
+      });
     });
   });
 });


### PR DESCRIPTION
These changes refactors the router store tests, where some tests in the router store are moved to integration tests and vice versa, ensuring that the test suite is better separated as unit vs integration tests.

## Changes
* Move `sends the expected path to history` integration tests to router store
* Move `history listen resource store interop` route transition tests from the router store to integration tests, and consolidate them into two tests rather than four
* Rename describe blocks and test cases as appropriate
* Test the `RouterContainer` over `Router` in the router store tests
* Test history v4/v5 for each test in router store, rather than a few
* Use `getRouterState()` or a local `getState` over `RouterStoreSubscriber` to cleanup the tests
* Use common render function in router store tests