### PR TITLE
Improve Plugin types

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -327,7 +327,7 @@ export type FindRouterContextOptions = {
   basePath?: string;
 };
 
-export type Plugin = {
+export interface Plugin {
   beforeRouteLoad?: (params: {
     context: RouterContext;
     nextContext: RouterContext;
@@ -341,4 +341,4 @@ export type Plugin = {
     nextContext: RouterContext;
   }) => void;
   [key: string]: any;
-};
+}

--- a/src/resources/plugin/index.ts
+++ b/src/resources/plugin/index.ts
@@ -43,9 +43,9 @@ const beforeLoad = ({
 
 type LoadedResources = Promise<RouteResourceResponse<unknown>[]>;
 
-type ResourcesPlugin = Plugin & {
+interface ResourcesPlugin extends Plugin {
   getSerializedResources: () => Promise<ResourceStoreData>;
-};
+}
 
 export const createResourcesPlugin = ({
   context: initialResourceContext,


### PR DESCRIPTION
Converting `Plugin` type to interface so that `Router` `plugins` prop would accept any type that implements `Plugin` or extends it