### PR TITLE
Fix exported Resources plugin types

### DIFF
--- a/resources/package.json
+++ b/resources/package.json
@@ -1,5 +1,5 @@
 {
-  "main": "../build/cjs/resources.js",
-  "module": "../build/esm/resources.js",
-  "types": "../build/cjs/resources.d.ts"
+  "main": "../build/cjs/resources/index.js",
+  "module": "../build/esm/resources/index.js",
+  "types": "../build/cjs/resources/index.d.ts"
 }

--- a/resources/package.json
+++ b/resources/package.json
@@ -1,5 +1,5 @@
 {
   "main": "../build/cjs/resources.js",
   "module": "../build/esm/resources.js",
-  "types": "../build/esm/resources.d.ts"
+  "types": "../build/cjs/resources.d.ts"
 }

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -1,1 +1,0 @@
-export { createResourcesPlugin } from './resources/plugin';

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -1,0 +1,1 @@
+export { createResourcesPlugin } from './plugin';


### PR DESCRIPTION
Fixing types export mismatch between `./package.json` (exports "cjs") and `./resources/package.json` (exports "esm")