### PR TITLE
Fix codemod error

### DIFF
--- a/codemods/transforms/use-resource-imports/index.ts
+++ b/codemods/transforms/use-resource-imports/index.ts
@@ -4,9 +4,31 @@ import {
 } from '@codeshift/utils';
 import type { FileInfo, API } from 'jscodeshift';
 
-import * as resources from '../../../resources';
-
-const resourcesImportSpecifiers = Object.keys(resources);
+const resourcesImportSpecifiers = [
+  'createResourcesPlugin',
+  'ResourceSubscriber',
+  'useResource',
+  'addResourcesListener',
+  'createResource',
+  'useResourceStoreContext',
+  'ResourceDependencyError',
+  'getResourceStore',
+  'ResourceStore',
+  'CreateResourceArgBase',
+  'CreateResourceArgSync',
+  'CreateResourceArgAsync',
+  'RouteResources',
+  'ResourceStoreContext',
+  'ResourceStoreData',
+  'RouteResource',
+  'RouteResourceError',
+  'RouteResourceLoading',
+  'RouteResourceResponse',
+  'RouteResourceUpdater',
+  'RouterDataContext',
+  'UseResourceHookResponse',
+  'mockRouteResourceResponse',
+];
 
 const packageName = 'react-resource-router';
 const resourcesPackageName = 'react-resource-router/resources';

--- a/codemods/transforms/use-resource-imports/index.ts
+++ b/codemods/transforms/use-resource-imports/index.ts
@@ -4,7 +4,7 @@ import {
 } from '@codeshift/utils';
 import type { FileInfo, API } from 'jscodeshift';
 
-import * as resources from '../../../src/resources';
+import * as resources from '../../../build/esm/resources/index';
 
 const resourcesImportSpecifiers = Object.keys(resources);
 

--- a/codemods/transforms/use-resource-imports/index.ts
+++ b/codemods/transforms/use-resource-imports/index.ts
@@ -4,7 +4,7 @@ import {
 } from '@codeshift/utils';
 import type { FileInfo, API } from 'jscodeshift';
 
-import * as resources from '../../../build/esm/resources/index';
+import * as resources from '../../../resources';
 
 const resourcesImportSpecifiers = Object.keys(resources);
 


### PR DESCRIPTION
When running `npx @codeshift/cli --packages "react-resource-router#use-resource-imports" ~my-project/**/*.tsx` I'm getting the following error as we do not ship `./src` folder to npm

![image](https://github.com/atlassian-labs/react-resource-router/assets/208444/d27a08dd-4789-4b71-aa94-48614a35d80b)

P.s I've tried to import from `./build/...` and `./resources`, both would not work for tests/eslint
