### PR TITLE
make component Route prop optional

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -108,7 +108,7 @@ export interface AdditionalRouteAttributes {}
 
 export type Route = InvariantRoute & {
   /** The component to render on match, typed explicitly */
-  component: ComponentType<RouteContext>;
+  component?: ComponentType<RouteContext>;
   EXPERIMENTAL__shouldReload?: ShouldReloadFunction;
 } & AdditionalRouteAttributes;
 

--- a/src/ui/route-component/index.tsx
+++ b/src/ui/route-component/index.tsx
@@ -5,7 +5,7 @@ import { useRouter } from '../../controllers';
 export const RouteComponent = () => {
   const [{ action, location, match, query, route }] = useRouter();
 
-  if (!route) {
+  if (!route || !route.component) {
     return null;
   }
 


### PR DESCRIPTION
Making `component` prop optional as now `resources` is an optional plugin and other plugins like `relay entrypoints` may not need `component` at all