### PR TITLE
Fix examples in docs and add notes about resources plugin

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -116,7 +116,7 @@ import {
   RouteComponent,
   createBrowserHistory,
 } from 'react-resource-router';
-import {createResourcesPlugin} from "react-resource-router/resources";
+import { createResourcesPlugin } from "react-resource-router/resources";
 import { appRoutes } from './routing/routes';
 
 const history = createBrowserHistory();

--- a/docs/README.md
+++ b/docs/README.md
@@ -108,7 +108,7 @@ export const appRoutes = [
 
 ### Use the Router
 
-Now that you've set up your resources, components and configuration correctly, all you need to do is mount the [Router](api/components.md#router) in your react tree with a [`RouteComponent`](api/components.md#routecomponent) as a child. It will do the rest!
+Now that you've set up your resources, components and configuration correctly, all you need to do is mount the [Router](api/components.md#router) with the [Resources Plugin](api/components?id=resources-plugin) in your react tree, and a [`RouteComponent`](api/components.md#routecomponent) as a child. It will do the rest!
 
 ```js
 import {
@@ -116,12 +116,14 @@ import {
   RouteComponent,
   createBrowserHistory,
 } from 'react-resource-router';
+import {createResourcesPlugin} from "react-resource-router/resources";
 import { appRoutes } from './routing/routes';
 
 const history = createBrowserHistory();
+const resourcesPlugin = createResourcesPlugin({});
 
 const App = () => (
-  <Router routes={appRoutes} history={history}>
+  <Router routes={appRoutes} history={history} plugins={[resourcesPlugin]}>
     <RouteComponent />
   </Router>
 );

--- a/docs/resources/concept.md
+++ b/docs/resources/concept.md
@@ -5,3 +5,5 @@ Router Resources are objects that are used by the router to fetch, cache and pro
 You can create these objects using the [`createResource`](./creation.md) function and then put them in the `resources` array on your route configuration object. Doing so means that each resources' data will be fetched as soon as the Router is mounted on initial page loads and on route transitions if the resources have expired.
 
 Since we recommend that your [`Router`](../api/components.md#router) sits as high up in your React tree as possible, it means that asynchronous requests for data are triggered as early as can be. This results in quicker meaningful render times.
+
+When using resources, you should initialise the resources plugin with [`createResourcesPlugin`](../api/components?id=resources-plugin), and ensure that this is loaded as a plugin when calling [`Router`](../api/components.md#router) in your app.


### PR DESCRIPTION
Many of the examples in the documentation no longer work with 0.24's breaking changes to the plugin system. This change fixes a handful of those examples, and adds documentation directing users to the resource plugin page if they're using resources in their app.