### PR TITLE
Fixed bug causing routes not to render on change

### DIFF
--- a/examples/basic-routing/index.tsx
+++ b/examples/basic-routing/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from 'react-dom';
+import { createRoot } from 'react-dom/client';
 
 import { About } from './about';
 import { Home } from './home';
@@ -42,4 +42,9 @@ const App = () => {
   );
 };
 
-render(<App />, document.getElementById('root'));
+const container = document.getElementById('root');
+if (!container)
+  throw new Error('No root element found to render basic routing example');
+
+const root = createRoot(container);
+root.render(<App />);

--- a/examples/hash-routing/index.tsx
+++ b/examples/hash-routing/index.tsx
@@ -1,7 +1,7 @@
 import { createHashHistory as createHashHistory4 } from 'history';
 import { createHashHistory as createHashHistory5 } from 'history-5';
 import React from 'react';
-import { render } from 'react-dom';
+import { createRoot } from 'react-dom/client';
 
 import { About } from './about';
 import { Home } from './home';
@@ -42,4 +42,9 @@ const App = () => {
   );
 };
 
-render(<App />, document.getElementById('root'));
+const container = document.getElementById('root');
+if (!container)
+  throw new Error('No root element found to render hash routing example');
+
+const root = createRoot(container);
+root.render(<App />);

--- a/examples/hooks/index.tsx
+++ b/examples/hooks/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from 'react-dom';
+import { createRoot } from 'react-dom/client';
 
 import { shouldReloadWhenRouteMatchChanges } from '../../src/utils';
 
@@ -68,4 +68,9 @@ const App = () => {
   );
 };
 
-render(<App />, document.getElementById('root'));
+const container = document.getElementById('root');
+if (!container)
+  throw new Error('No root element found to render hooks example');
+
+const root = createRoot(container);
+root.render(<App />);

--- a/examples/hydration/index.tsx
+++ b/examples/hydration/index.tsx
@@ -1,6 +1,6 @@
 import { createMemoryHistory } from 'history';
 import React from 'react';
-import { render } from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { defaultRegistry } from 'react-sweet-state';
 
 import { homeRoute } from './routes';
@@ -53,7 +53,12 @@ const main = async () => {
     );
   };
 
-  render(<App />, document.getElementById('root'));
+  const container = document.getElementById('root');
+  if (!container)
+    throw new Error('No root element found to render hydration example');
+
+  const root = createRoot(container);
+  root.render(<App />);
 };
 
 main();

--- a/examples/routing-with-resources/index.tsx
+++ b/examples/routing-with-resources/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from 'react-dom';
+import { createRoot } from 'react-dom/client';
 
 import { homeRoute, aboutRoute } from './routes';
 
@@ -28,4 +28,9 @@ const App = () => {
   );
 };
 
-render(<App />, document.getElementById('root'));
+const container = document.getElementById('root');
+if (!container)
+  throw new Error('No root element found to render resources example');
+
+const root = createRoot(container);
+root.render(<App />);

--- a/src/controllers/router-store/index.tsx
+++ b/src/controllers/router-store/index.tsx
@@ -383,12 +383,16 @@ export const RouterContainer = createContainer<State, Actions, ContainerProps>(
         dispatch(actions.bootstrapStore(props));
         !isServerEnvironment() && dispatch(actions.loadPlugins());
       },
-    onCleanup: () => () => {
+    onCleanup: () => state => {
       if (process.env.NODE_ENV === 'development') {
         // eslint-disable-next-line no-console
         console.warn(
           `Warning: react-resource-router has been unmounted! Was this intentional? Resources will be refetched when the router is mounted again.`
         );
+      }
+      if (!isServerEnvironment()) {
+        const { unlisten } = state.getState();
+        unlisten && unlisten();
       }
     },
   }

--- a/src/controllers/router/index.tsx
+++ b/src/controllers/router/index.tsx
@@ -15,13 +15,13 @@ export const Router = ({
   onPrefetch,
   routes,
 }: RouterProps) => {
-  useEffect(() => {
-    const { unlisten } = getRouterState();
+  const { unlisten } = getRouterState();
 
+  useEffect(() => {
     return () => {
       unlisten && unlisten();
     };
-  }, []);
+  }, [unlisten]);
 
   return (
     <RouterContainer

--- a/src/controllers/router/index.tsx
+++ b/src/controllers/router/index.tsx
@@ -1,7 +1,7 @@
 import { createMemoryHistory } from 'history';
-import React, { useMemo, useEffect } from 'react';
+import React, { useMemo } from 'react';
 
-import { getRouterState, RouterContainer } from '../router-store';
+import { RouterContainer } from '../router-store';
 
 import { RouterProps, MemoryRouterProps } from './types';
 
@@ -15,14 +15,6 @@ export const Router = ({
   onPrefetch,
   routes,
 }: RouterProps) => {
-  const { unlisten } = getRouterState();
-
-  useEffect(() => {
-    return () => {
-      unlisten && unlisten();
-    };
-  }, [unlisten]);
-
   return (
     <RouterContainer
       basePath={basePath}

--- a/src/controllers/router/test.tsx
+++ b/src/controllers/router/test.tsx
@@ -46,7 +46,7 @@ describe('<Router />', () => {
     expect(screen.getByText('test')).toBeInTheDocument();
   });
 
-  it('calls history.listen()() on unmount', () => {
+  it('calls history.listen()() on unmount', async () => {
     const unlisten = jest.fn();
     jest.spyOn(history, 'listen').mockReturnValue(unlisten);
 
@@ -54,7 +54,7 @@ describe('<Router />', () => {
       <Router history={history} routes={routes} plugins={[]} />
     );
 
-    unmount();
+    await unmount();
 
     expect(unlisten).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
Fixes: https://github.com/atlassian-labs/react-resource-router/pull/224

- Fixed broken `useEffect` that was stopping correct rendering in `<StrictMode>`
- Updated examples to use the new React18 rendering method
- Add strict mode options to the integration tests

I did notice that the Hydration example is broken (even before the changes). I logged a bug for this: https://github.com/atlassian-labs/react-resource-router/issues/223