### PR TITLE
Supported basePath for to prop when passed as string. Resolving acces…

### DIFF
--- a/src/ui/link/index.tsx
+++ b/src/ui/link/index.tsx
@@ -71,7 +71,7 @@ const Link = forwardRef<HTMLButtonElement | HTMLAnchorElement, LinkProps>(
               generateLocationFromPath(route.path, routeAttributes)
             )) ||
           ''
-        : to;
+        : `${routeAttributes.basePath}${to}`;
 
     const triggerPrefetch = useCallback(() => {
       // ignore if async route not ready yet

--- a/src/ui/link/test.tsx
+++ b/src/ui/link/test.tsx
@@ -67,6 +67,12 @@ describe('<Link />', () => {
     expect(linkElement).toHaveAttribute('href', newPath);
   });
 
+  it('should support the `to` prop with basePath', () => {
+    renderInRouter('my link', { to: '/my-page/1?foo=bar' }, '/base');
+    const linkElement = screen.getByRole('link', { name: 'my link' });
+    expect(linkElement).toHaveAttribute('href', `/base/my-page/1?foo=bar`);
+  });
+
   it('should pass props to the child element', () => {
     renderInRouter('my link', {
       ...defaultProps,


### PR DESCRIPTION
Resolves https://github.com/atlassian-labs/react-resource-router/issues/225

Supported basePath for to prop when passed as string.
Resolves accessibility issues for new tabs/window interactions.