### PR TITLE
Supported basePath for to prop when passed as string. Resolving acces…

### DIFF
--- a/src/ui/link/index.tsx
+++ b/src/ui/link/index.tsx
@@ -72,6 +72,16 @@ const Link = forwardRef<HTMLButtonElement | HTMLAnchorElement, LinkProps>(
             )) ||
           ''
         : to;
+    const hrefDestination =
+      href != null
+        ? href
+        : typeof to !== 'string'
+        ? (route &&
+            createPath(
+              generateLocationFromPath(route.path, routeAttributes)
+            )) ||
+          ''
+        : `${routeAttributes.basePath}${to}`;
 
     const triggerPrefetch = useCallback(() => {
       // ignore if async route not ready yet
@@ -145,7 +155,7 @@ const Link = forwardRef<HTMLButtonElement | HTMLAnchorElement, LinkProps>(
       validLinkType,
       {
         ...rest,
-        href: linkDestination,
+        href: hrefDestination,
         target,
         onClick: handleLinkPress,
         onKeyDown: handleLinkPress,

--- a/src/ui/link/index.tsx
+++ b/src/ui/link/index.tsx
@@ -72,16 +72,8 @@ const Link = forwardRef<HTMLButtonElement | HTMLAnchorElement, LinkProps>(
             )) ||
           ''
         : to;
-    const hrefDestination =
-      href != null
-        ? href
-        : typeof to !== 'string'
-        ? (route &&
-            createPath(
-              generateLocationFromPath(route.path, routeAttributes)
-            )) ||
-          ''
-        : `${routeAttributes.basePath}${to}`;
+    const staticBasePath =
+      href == null && typeof to === 'string' ? routeAttributes.basePath : '';
 
     const triggerPrefetch = useCallback(() => {
       // ignore if async route not ready yet
@@ -155,7 +147,7 @@ const Link = forwardRef<HTMLButtonElement | HTMLAnchorElement, LinkProps>(
       validLinkType,
       {
         ...rest,
-        href: hrefDestination,
+        href: `${staticBasePath}${linkDestination}`,
         target,
         onClick: handleLinkPress,
         onKeyDown: handleLinkPress,

--- a/src/ui/link/test.tsx
+++ b/src/ui/link/test.tsx
@@ -67,6 +67,30 @@ describe('<Link />', () => {
     expect(linkElement).toHaveAttribute('href', newPath);
   });
 
+  it('should support the `to` prop with basePath', () => {
+    renderInRouter('my link', { to: '/my-page/1?foo=bar' }, '/base');
+    const linkElement = screen.getByRole('link', { name: 'my link' });
+    expect(linkElement).toHaveAttribute('href', `/base/my-page/1?foo=bar`);
+  });
+
+  it('should push history with correct link given basePath', async () => {
+    const user = userEvent.setup();
+    renderInRouter(
+      'my link',
+      {
+        to: '/my-page/1?foo=bar',
+      },
+      '/base'
+    );
+
+    await user.click(screen.getByRole('link', { name: 'my link' }));
+
+    expect(HistoryMock.push).toHaveBeenCalledWith(
+      '/base/my-page/1?foo=bar',
+      undefined
+    );
+  });
+
   it('should pass props to the child element', () => {
     renderInRouter('my link', {
       ...defaultProps,


### PR DESCRIPTION
Resolves https://github.com/atlassian-labs/react-resource-router/issues/225

Supported basePath for to prop when passed as string.
Resolves accessibility issues for new tabs/window interactions.

Test added:
* should support the `to` prop with basePath
* should push history with correct link given basePath

![basePath](https://github.com/atlassian-labs/react-resource-router/assets/137123546/36159ccb-29c0-4199-acd7-f827945490f0)
