### PR TITLE
Add no-cycle eslint rule

### DIFF
--- a/.changeset/angry-points-live.md
+++ b/.changeset/angry-points-live.md
@@ -1,0 +1,5 @@
+---
+"react-resource-router": patch
+---
+
+Remove cyclic imports and add eslint rule to stop future issues

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,7 +45,7 @@ module.exports = {
     'react-hooks/exhaustive-deps': 'warn',
     'react-hooks/rules-of-hooks': 'error',
     semi: 'off',
-    'import/no-cycle': 'warn',
+    'import/no-cycle': 'error',
   },
   overrides: [
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,6 +45,7 @@ module.exports = {
     'react-hooks/exhaustive-deps': 'warn',
     'react-hooks/rules-of-hooks': 'error',
     semi: 'off',
+    'import/no-cycle': 'warn',
   },
   overrides: [
     {

--- a/examples/routing-with-resources/about.tsx
+++ b/examples/routing-with-resources/about.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+// eslint-disable-next-line import/no-cycle
 import { homeRoute } from './routes';
 
 import { Link, useQueryParam } from 'react-resource-router';

--- a/examples/routing-with-resources/home.tsx
+++ b/examples/routing-with-resources/home.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+// eslint-disable-next-line import/no-cycle
 import { aboutRoute } from './routes';
 
 import { Link } from 'react-resource-router';

--- a/examples/routing-with-resources/routes.tsx
+++ b/examples/routing-with-resources/routes.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-cycle */
 import { About, aboutResource } from './about';
 import { Home, homeResource } from './home';
 

--- a/src/resources/controllers/resource-store/utils/get-resources-for-next-location/index.ts
+++ b/src/resources/controllers/resource-store/utils/get-resources-for-next-location/index.ts
@@ -1,4 +1,4 @@
-import { RouterContext } from '../../../../../index';
+import { type RouterContext } from '../../../../../index';
 import {
   ResourceStoreContext,
   RouteResource,

--- a/src/resources/controllers/use-resource/index.ts
+++ b/src/resources/controllers/use-resource/index.ts
@@ -1,19 +1,21 @@
 import { useCallback, useMemo } from 'react';
 import { createHook } from 'react-sweet-state';
 
+import { type RouterContext } from '../../../common/types';
 import {
-  RouterContext,
   RouterStore,
   useRouterStoreActions,
+} from '../../../controllers/router-store';
+import {
   type EntireRouterState,
   type AllRouterActions,
-} from '../../../index';
+} from '../../../controllers/router-store/types';
 import {
   RouteResource,
   RouteResourceResponse,
   RouteResourceUpdater,
   UseResourceHookResponse,
-} from '../../index';
+} from '../../common/types';
 import { useResourceStore, useResourceStoreActions } from '../resource-store';
 
 type UseResourceOptions = {

--- a/src/resources/plugin/index.ts
+++ b/src/resources/plugin/index.ts
@@ -1,4 +1,4 @@
-import { Plugin, RouterContext } from '../../index';
+import type { Plugin, RouterContext } from '../../index';
 import type {
   ResourceStoreContext,
   RouteResourceResponse,


### PR DESCRIPTION
We are trying to mock our imports of react-resource-router using snippet below, however due to the cyclic import of react-resource-router, we are getting a "Cannot read properties of undefined (reading 'ResourceDependencyError')". I believe this is due to the cyclic imports that means when Jest tries to import the actual module, and then when the submodules in react-resource-router imports the root index file, this file points to the Jest mock which has not been fully set up. This causes an property of undefined error.

```js
jest.mock('react-resource-router', () => ({
   ...jest.requireActual('react-resource-router'),
   useRouter: jest.fn(),
});
```
