### PR TITLE
Support basePath for relative href prop

### DIFF
--- a/.changeset/happy-fireants-visit.md
+++ b/.changeset/happy-fireants-visit.md
@@ -1,0 +1,5 @@
+---
+"react-resource-router": patch
+---
+
+Support basePath for relative href prop

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-resource-router",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-resource-router",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.debounce": "^4.0.8",

--- a/src/ui/link/index.tsx
+++ b/src/ui/link/index.tsx
@@ -72,7 +72,7 @@ const Link = forwardRef<HTMLButtonElement | HTMLAnchorElement, LinkProps>(
               )) ||
             ''
           : to;
-    const IS_ABSOLUTE_LINK_REGEX = /^(?:(http|https):\/\/)/;
+    const IS_ABSOLUTE_LINK_REGEX = /^((?:(http|https):\/\/)|\/\/)/;
     const staticBasePath =
       (href != null && !IS_ABSOLUTE_LINK_REGEX.test(href)) || typeof to === 'string' ? routeAttributes.basePath : '';
 

--- a/src/ui/link/index.tsx
+++ b/src/ui/link/index.tsx
@@ -72,8 +72,9 @@ const Link = forwardRef<HTMLButtonElement | HTMLAnchorElement, LinkProps>(
               )) ||
             ''
           : to;
+    const IS_EXTERNAL_LINK_REGEX = /^(?:(http|https):\/\/)/;
     const staticBasePath =
-      href != null || typeof to === 'string' ? routeAttributes.basePath : '';
+      (href != null && !IS_EXTERNAL_LINK_REGEX.test(href)) || typeof to === 'string' ? routeAttributes.basePath : '';
 
     const triggerPrefetch = useCallback(() => {
       // ignore if async route not ready yet

--- a/src/ui/link/index.tsx
+++ b/src/ui/link/index.tsx
@@ -74,7 +74,10 @@ const Link = forwardRef<HTMLButtonElement | HTMLAnchorElement, LinkProps>(
           : to;
     const IS_ABSOLUTE_LINK_REGEX = /^((?:(http|https):\/\/)|\/\/)/;
     const staticBasePath =
-      (href != null && !IS_ABSOLUTE_LINK_REGEX.test(href)) || typeof to === 'string' ? routeAttributes.basePath : '';
+      (href != null && !IS_ABSOLUTE_LINK_REGEX.test(href)) ||
+      typeof to === 'string'
+        ? routeAttributes.basePath
+        : '';
 
     const triggerPrefetch = useCallback(() => {
       // ignore if async route not ready yet

--- a/src/ui/link/index.tsx
+++ b/src/ui/link/index.tsx
@@ -73,7 +73,7 @@ const Link = forwardRef<HTMLButtonElement | HTMLAnchorElement, LinkProps>(
             ''
           : to;
     const staticBasePath =
-      href == null && typeof to === 'string' ? routeAttributes.basePath : '';
+      href != null || typeof to === 'string' ? routeAttributes.basePath : '';
 
     const triggerPrefetch = useCallback(() => {
       // ignore if async route not ready yet

--- a/src/ui/link/index.tsx
+++ b/src/ui/link/index.tsx
@@ -72,9 +72,9 @@ const Link = forwardRef<HTMLButtonElement | HTMLAnchorElement, LinkProps>(
               )) ||
             ''
           : to;
-    const IS_EXTERNAL_LINK_REGEX = /^(?:(http|https):\/\/)/;
+    const IS_ABSOLUTE_LINK_REGEX = /^(?:(http|https):\/\/)/;
     const staticBasePath =
-      (href != null && !IS_EXTERNAL_LINK_REGEX.test(href)) || typeof to === 'string' ? routeAttributes.basePath : '';
+      (href != null && !IS_ABSOLUTE_LINK_REGEX.test(href)) || typeof to === 'string' ? routeAttributes.basePath : '';
 
     const triggerPrefetch = useCallback(() => {
       // ignore if async route not ready yet

--- a/src/ui/link/test.tsx
+++ b/src/ui/link/test.tsx
@@ -91,7 +91,7 @@ describe('<Link />', () => {
     );
   });
 
-  it('should push history with correct link for href when given basePath', () => {
+  it('should push history with correct link for relative href when given basePath', () => {
     renderInRouter(
       'my link',
       {
@@ -102,6 +102,20 @@ describe('<Link />', () => {
     expect(screen.getByRole('link', { name: 'my link' })).toHaveAttribute(
       'href',
       '/base/route/1?foo=bar'
+    );
+  });
+
+  it('should not add basePath for external links', () => {
+    renderInRouter(
+      'my link',
+      {
+        href: 'https://www.atlassian.com/',
+      },
+      '/base'
+    );
+    expect(screen.getByRole('link', { name: 'my link' })).toHaveAttribute(
+      'href',
+      'https://www.atlassian.com/'
     );
   });
 

--- a/src/ui/link/test.tsx
+++ b/src/ui/link/test.tsx
@@ -105,7 +105,7 @@ describe('<Link />', () => {
     );
   });
 
-  it('should not add basePath for external links', () => {
+  it('should not add basePath for absolute links', () => {
     renderInRouter(
       'my link',
       {

--- a/src/ui/link/test.tsx
+++ b/src/ui/link/test.tsx
@@ -119,6 +119,20 @@ describe('<Link />', () => {
     );
   });
 
+  it('should not add basePath for absolute links with no protocol specified', () => {
+    renderInRouter(
+      'my link',
+      {
+        href: '//www.atlassian.com/',
+      },
+      '/base'
+    );
+    expect(screen.getByRole('link', { name: 'my link' })).toHaveAttribute(
+      'href',
+      '//www.atlassian.com/'
+    );
+  });
+
   it('should pass props to the child element', () => {
     renderInRouter('my link', {
       ...defaultProps,

--- a/src/ui/link/test.tsx
+++ b/src/ui/link/test.tsx
@@ -91,6 +91,20 @@ describe('<Link />', () => {
     );
   });
 
+  it('should push history with correct link for href when given basePath', () => {
+    renderInRouter(
+      'my link',
+      {
+        href: '/route/1?foo=bar',
+      },
+      '/base'
+    );
+    expect(screen.getByRole('link', { name: 'my link' })).toHaveAttribute(
+      'href',
+      '/base/route/1?foo=bar'
+    );
+  });
+
   it('should pass props to the child element', () => {
     renderInRouter('my link', {
       ...defaultProps,


### PR DESCRIPTION
We are using the `basePath` prop for navigation in our application and for our side navigation we are using the MenuLinkItem which takes an `href` prop. Because of this, we did not see the `basePath` being added to the route when hovering over the side navigation. 

I found [this PR](https://github.com/atlassian-labs/react-resource-router/pull/227/files) which prefixes basePath when using the `to` prop, and I was wondering if this could be extended to relative hrefs as well. We added a patch fix for this in our code, but I created this PR to upstream this change of prefixing to relative `href` paths, after reaching out to @pancaspe87 