### PR TITLE
Supporting navigation to / and basePath when basePath is defined

### DIFF
--- a/.changeset/ninety-penguins-speak.md
+++ b/.changeset/ninety-penguins-speak.md
@@ -1,5 +1,5 @@
 ---
-"react-resource-router": patch
+"react-resource-router": minor
 ---
 
 Supporting navigation to / and basePath when basePath is defined

--- a/.changeset/ninety-penguins-speak.md
+++ b/.changeset/ninety-penguins-speak.md
@@ -1,0 +1,5 @@
+---
+"react-resource-router": patch
+---
+
+Supporting navigation to / and basePath when basePath is defined

--- a/src/common/utils/match-route/index.ts
+++ b/src/common/utils/match-route/index.ts
@@ -26,6 +26,8 @@ const matchRoute = <T extends Route | InvariantRoute>(
   queryParams: Query = {},
   basePath = ''
 ) => {
+  // if navigating to to `/` or just basePath, then do not append basePath
+  const updatedBasePath = ['/', basePath].includes(pathname) ? '' : basePath;
   const queryParamObject =
     typeof queryParams === 'string'
       ? (qs.parse(queryParams) as Query)
@@ -34,7 +36,7 @@ const matchRoute = <T extends Route | InvariantRoute>(
   const cachedMatch = matchRouteCache.get<T>(
     pathname,
     queryParamObject,
-    basePath
+    updatedBasePath
   );
   if (cachedMatch && routes.includes(cachedMatch.route)) return cachedMatch;
 
@@ -43,10 +45,10 @@ const matchRoute = <T extends Route | InvariantRoute>(
       routes[i],
       pathname,
       queryParamObject,
-      basePath
+      updatedBasePath
     );
     if (matchedRoute) {
-      matchRouteCache.set(pathname, queryParamObject, basePath, matchedRoute);
+      matchRouteCache.set(pathname, queryParamObject, updatedBasePath, matchedRoute);
 
       return matchedRoute;
     }

--- a/src/common/utils/match-route/index.ts
+++ b/src/common/utils/match-route/index.ts
@@ -48,7 +48,12 @@ const matchRoute = <T extends Route | InvariantRoute>(
       updatedBasePath
     );
     if (matchedRoute) {
-      matchRouteCache.set(pathname, queryParamObject, updatedBasePath, matchedRoute);
+      matchRouteCache.set(
+        pathname,
+        queryParamObject,
+        updatedBasePath,
+        matchedRoute
+      );
 
       return matchedRoute;
     }

--- a/src/common/utils/match-route/test.ts
+++ b/src/common/utils/match-route/test.ts
@@ -151,15 +151,25 @@ describe('matchRoute()', () => {
       ).toBeNull();
 
       expect(
-        // @ts-ignore
-        matchRoute([routeA, routeB], '/base/abc', DEFAULT_QUERY_PARAMS, basePath)
+        matchRoute(
+          // @ts-ignore
+          [routeA, routeB],
+          '/base/abc',
+          DEFAULT_QUERY_PARAMS,
+          basePath
+        )
       ).toMatchObject({
         route: routeA,
       });
 
       expect(
-        // @ts-ignore
-        matchRoute([routeB, routeA], '/base/def', DEFAULT_QUERY_PARAMS, basePath)
+        matchRoute(
+          // @ts-ignore
+          [routeB, routeA],
+          '/base/def',
+          DEFAULT_QUERY_PARAMS,
+          basePath
+        )
       ).toMatchObject({
         route: routeB,
       });
@@ -207,12 +217,16 @@ describe('matchRoute()', () => {
       });
 
       expect(
-        // @ts-ignore
-        matchRoute([routeA, routeC, routeB], '/base/abc', DEFAULT_QUERY_PARAMS, basePath)
+        matchRoute(
+          // @ts-ignore
+          [routeA, routeC, routeB],
+          '/base/abc',
+          DEFAULT_QUERY_PARAMS,
+          basePath
+        )
       ).toMatchObject({
         route: routeC,
       });
-
     });
   });
 

--- a/src/common/utils/match-route/test.ts
+++ b/src/common/utils/match-route/test.ts
@@ -156,9 +156,10 @@ describe('matchRoute()', () => {
       ).toMatchObject({
         route: routeA,
       });
+
       expect(
         // @ts-ignore
-        matchRoute([routeB, routeA], '/base/abc', DEFAULT_QUERY_PARAMS, basePath)
+        matchRoute([routeB, routeA], '/base/def', DEFAULT_QUERY_PARAMS, basePath)
       ).toMatchObject({
         route: routeB,
       });
@@ -166,13 +167,14 @@ describe('matchRoute()', () => {
 
     it('should ignore basePath when navigating to just basePath', () => {
       const routeA = { path: '/base', component: Noop };
-      const routeB = { path: '/:bar', component: Noop };
+      const routeB = { path: '/', component: Noop };
+      const routeC = { path: '/:bar', component: Noop };
       const basePath = '/base';
       expect(
         matchRoute(
           // @ts-ignore
-          [routeA, routeB],
-          '/base',
+          [routeA, routeB, routeC],
+          basePath,
           DEFAULT_QUERY_PARAMS,
           basePath
         )
@@ -181,16 +183,36 @@ describe('matchRoute()', () => {
       });
 
       expect(
-        // @ts-ignore
-        matchRoute([routeA, routeB], '/abc', DEFAULT_QUERY_PARAMS, basePath)
-      ).toBeNull();
+        matchRoute(
+          // @ts-ignore
+          [routeA, routeB, routeC],
+          '/base/base',
+          DEFAULT_QUERY_PARAMS,
+          basePath
+        )
+      ).toMatchObject({
+        route: routeA,
+      });
 
       expect(
-        // @ts-ignore
-        matchRoute([routeA, routeB], '/base/abc', DEFAULT_QUERY_PARAMS, basePath)
+        matchRoute(
+          // @ts-ignore
+          [routeC, routeA, routeB],
+          '/base/',
+          DEFAULT_QUERY_PARAMS,
+          basePath
+        )
       ).toMatchObject({
         route: routeB,
       });
+
+      expect(
+        // @ts-ignore
+        matchRoute([routeA, routeC, routeB], '/base/abc', DEFAULT_QUERY_PARAMS, basePath)
+      ).toMatchObject({
+        route: routeC,
+      });
+
     });
   });
 

--- a/src/common/utils/match-route/test.ts
+++ b/src/common/utils/match-route/test.ts
@@ -128,6 +128,70 @@ describe('matchRoute()', () => {
         route: routeB,
       });
     });
+
+    it('should ignore basePath when navigating to / without path params', () => {
+      const routeA = { path: '/', component: Noop };
+      const routeB = { path: '/:bar', component: Noop };
+      const basePath = '/base';
+      expect(
+        matchRoute(
+          // @ts-ignore
+          [routeA, routeB],
+          '/',
+          DEFAULT_QUERY_PARAMS,
+          basePath
+        )
+      ).toMatchObject({
+        route: routeA,
+      });
+
+      expect(
+        // @ts-ignore
+        matchRoute([routeA, routeB], '/abc', DEFAULT_QUERY_PARAMS, basePath)
+      ).toBeNull();
+
+      expect(
+        // @ts-ignore
+        matchRoute([routeA, routeB], '/base/abc', DEFAULT_QUERY_PARAMS, basePath)
+      ).toMatchObject({
+        route: routeA,
+      });
+      expect(
+        // @ts-ignore
+        matchRoute([routeB, routeA], '/base/abc', DEFAULT_QUERY_PARAMS, basePath)
+      ).toMatchObject({
+        route: routeB,
+      });
+    });
+
+    it('should ignore basePath when navigating to just basePath', () => {
+      const routeA = { path: '/base', component: Noop };
+      const routeB = { path: '/:bar', component: Noop };
+      const basePath = '/base';
+      expect(
+        matchRoute(
+          // @ts-ignore
+          [routeA, routeB],
+          '/base',
+          DEFAULT_QUERY_PARAMS,
+          basePath
+        )
+      ).toMatchObject({
+        route: routeA,
+      });
+
+      expect(
+        // @ts-ignore
+        matchRoute([routeA, routeB], '/abc', DEFAULT_QUERY_PARAMS, basePath)
+      ).toBeNull();
+
+      expect(
+        // @ts-ignore
+        matchRoute([routeA, routeB], '/base/abc', DEFAULT_QUERY_PARAMS, basePath)
+      ).toMatchObject({
+        route: routeB,
+      });
+    });
   });
 
   describe('query', () => {


### PR DESCRIPTION
The current issue is that when `basePath` is defined (e.g. `/base`), even when we pass in `/` and `/base` as routes to RRR, navigating to `url.com/` or `url.com/base` results in a 404, because 

- `/` becomes `/base/` and 
- `/base` becomes `/base/base`

when trying to find matching routes, and so now no routes match `/` or `/base`.  This PR is making an update so that when the user is navigating to `/` or `/base` the base path is ignored and they become valid routes to match on. `/base/` is still a valid route