### PR TITLE
pass onKeyDown to Link component

### DIFF
--- a/.changeset/fruity-bags-love.md
+++ b/.changeset/fruity-bags-love.md
@@ -1,0 +1,5 @@
+---
+'react-resource-router': patch
+---
+
+pass down onKeyDown to Link

--- a/package.json
+++ b/package.json
@@ -140,6 +140,5 @@
   },
   "engines": {
     "node": ">=16.0"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -140,5 +140,6 @@
   },
   "engines": {
     "node": ">=16.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/common/utils/event/index.ts
+++ b/src/common/utils/event/index.ts
@@ -1,3 +1,5 @@
+import type { KeyboardEvent } from 'react';
+
 export const isModifiedEvent = (event: { [key: string]: any }) =>
   !!(event.metaKey || event.altKey || event.ctrlKey || event.shiftKey);
 

--- a/src/ui/link/index.tsx
+++ b/src/ui/link/index.tsx
@@ -31,6 +31,7 @@ const Link = forwardRef<HTMLButtonElement | HTMLAnchorElement, LinkProps>(
       href = undefined,
       to = undefined,
       onClick = undefined,
+      onKeyDown = undefined,
       onMouseEnter = undefined,
       onMouseLeave = undefined,
       onPointerDown = undefined,
@@ -103,6 +104,7 @@ const Link = forwardRef<HTMLButtonElement | HTMLAnchorElement, LinkProps>(
     const handleLinkPress = (e: MouseEvent | KeyboardEvent) =>
       handleNavigation(e, {
         onClick,
+        onKeyDown,
         target,
         replace,
         routerActions,

--- a/src/ui/link/test.tsx
+++ b/src/ui/link/test.tsx
@@ -362,7 +362,9 @@ describe('<Link />', () => {
   describe('when the link has focus, and a keypress is fired', () => {
     it('should navigate if the key was an `enter`', async () => {
       const user = userEvent.setup();
-      renderInRouter('my link', { href: newPath });
+      const mockKeyHandler = jest.fn();
+
+      renderInRouter('my link', { href: newPath, onKeyDown: mockKeyHandler });
 
       const linkElement = screen.getByRole('link', { name: 'my link' });
       linkElement.focus();
@@ -370,6 +372,7 @@ describe('<Link />', () => {
 
       expect(HistoryMock.push).toHaveBeenCalledTimes(1);
       expect(HistoryMock.push).toHaveBeenCalledWith(newPath, undefined);
+      expect(mockKeyHandler).not.toHaveBeenCalled();
     });
 
     it('should not navigate for any other key', async () => {
@@ -381,6 +384,19 @@ describe('<Link />', () => {
       await user.keyboard('{a}');
 
       expect(HistoryMock.push).not.toHaveBeenCalled();
+    });
+
+    it('should respect onKeyDown as long as it is not {Enter}', async () => {
+      const user = userEvent.setup();
+      const mockKeyHandler = jest.fn();
+      renderInRouter('my link', { href: newPath, onKeyDown: mockKeyHandler });
+
+      const linkElement = screen.getByRole('link', { name: 'my link' });
+      linkElement.focus();
+      await user.keyboard('{a}');
+
+      expect(HistoryMock.push).not.toHaveBeenCalled();
+      expect(mockKeyHandler).toHaveBeenCalled();
     });
   });
 

--- a/src/ui/link/utils/handle-navigation.tsx
+++ b/src/ui/link/utils/handle-navigation.tsx
@@ -1,6 +1,6 @@
-import { KeyboardEvent, MouseEvent } from 'react';
+import type { KeyboardEvent, MouseEvent } from 'react';
 
-import { Route } from '../../../common/types';
+import type { Route } from '../../../common/types';
 import { isKeyboardEvent, isModifiedEvent } from '../../../common/utils/event';
 
 type LinkNavigationEvent = MouseEvent | KeyboardEvent;
@@ -16,15 +16,27 @@ type LinkPressArgs = {
   replace: boolean;
   href: string;
   onClick?: (e: LinkNavigationEvent) => void;
+  onKeyDown?: (e: KeyboardEvent<HTMLAnchorElement>) => void;
   to: [Route, any] | void;
   state?: unknown;
 };
 
 export const handleNavigation = (
   event: any,
-  { onClick, target, replace, routerActions, href, to, state }: LinkPressArgs
+  {
+    onClick,
+    onKeyDown,
+    target,
+    replace,
+    routerActions,
+    href,
+    to,
+    state,
+  }: LinkPressArgs
 ): void => {
   if (isKeyboardEvent(event) && event.key !== 'Enter') {
+    onKeyDown?.(event as KeyboardEvent<HTMLAnchorElement>);
+
     return;
   }
 


### PR DESCRIPTION
current state:
- onKeyDown points to `onLinkPressed` -> `handleNavigation` which swallows the original onKeyDown.
- onClick is properly passed to `onLinkPressed` -> `handleNavigation`

pr state: 
- passes onKeyDown to `handleNavigation` (which one could argue we should handle in the Link component itself, but that was a little bit bigger of a refactor - which I can do if the team wants); when the key is not Enter, the onKeyDown will be fired. 