### PR TITLE
Replace lodash with native implementations and modernise code patterns

### DIFF
--- a/.changeset/nervous-cats-warn.md
+++ b/.changeset/nervous-cats-warn.md
@@ -1,0 +1,5 @@
+---
+"react-resource-router": minor
+---
+
+Replace lodash with native implementations and modernise code patterns

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,14 @@
 {
   "name": "react-resource-router",
-  "version": "0.29.1",
+  "version": "0.30.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-resource-router",
-      "version": "0.29.1",
+      "version": "0.30.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "lodash.debounce": "^4.0.8",
-        "lodash.noop": "^3.0.1",
         "path-to-regexp": "^6.3.0",
         "react-sweet-state": "^2.6.4",
         "url-parse": "^1.5.10"
@@ -40,8 +38,6 @@
         "@types/history-5": "npm:@types/history@^5.0.0",
         "@types/jest": "^29.5.12",
         "@types/jscodeshift": "^0.11.11",
-        "@types/lodash.debounce": "^4.0.9",
-        "@types/lodash.noop": "^3.0.9",
         "@types/react": "^18.2.64",
         "@types/react-dom": "^18.2.21",
         "@types/url-parse": "^1.4.11",
@@ -6166,18 +6162,6 @@
         "@types/ms": "*"
       }
     },
-    "node_modules/@types/eslint": {
-      "version": "8.56.5",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.5.tgz",
-      "integrity": "sha512-u5/YPJHo1tvkSF2CE0USEkxon82Z5DBy2xR+qfyYNszpX9qcs4sT6uq2kBbj4BXY1+DBGDPnrhMZV3pKWGNukw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
     "node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
@@ -6369,31 +6353,6 @@
       "resolved": "https://registry.npmjs.org/@types/lockfile/-/lockfile-1.0.4.tgz",
       "integrity": "sha512-Q8oFIHJHr+htLrTXN2FuZfg+WXVHQRwU/hC2GpUu+Q8e3FUM9EDkS2pE3R2AO1ZGu56f479ybdMCNF1DAu8cAQ==",
       "dev": true
-    },
-    "node_modules/@types/lodash": {
-      "version": "4.14.183",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.183.tgz",
-      "integrity": "sha512-UXavyuxzXKMqJPEpFPri6Ku5F9af6ZJXUneHhvQJxavrEjuHkFp2YnDWHcxJiG7hk8ZkWqjcyNeW1s/smZv5cw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/lodash.debounce": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.9.tgz",
-      "integrity": "sha512-Ma5JcgTREwpLRwMM+XwBR7DaWe96nC38uCBDFKZWbNKD+osjVzdpnUSwBcqCptrp16sSOLBAUb50Car5I0TCsQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/lodash": "*"
-      }
-    },
-    "node_modules/@types/lodash.noop": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@types/lodash.noop/-/lodash.noop-3.0.9.tgz",
-      "integrity": "sha512-KS47MA78vxE+Stvhpd5QEfNpFgwOmKcZMpT8ATNotTrlWdIxpDDPYCMJgcCFDaXHb2AmKhCu4oFM/2HezwUhGA==",
-      "dev": true,
-      "dependencies": {
-        "@types/lodash": "*"
-      }
     },
     "node_modules/@types/mime": {
       "version": "3.0.1",
@@ -18151,6 +18110,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -18158,12 +18118,6 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.noop": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-3.0.1.tgz",
-      "integrity": "sha512-TmYdmu/pebrdTIBDK/FDx9Bmfzs9x0sZG6QIJuMDTqEPfeciLcN13ij+cOd0i9vwJfBtbG9UQ+C7MkXgYxrIJg==",
       "license": "MIT"
     },
     "node_modules/lodash.startcase": {
@@ -30091,18 +30045,6 @@
         "@types/ms": "*"
       }
     },
-    "@types/eslint": {
-      "version": "8.56.5",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.5.tgz",
-      "integrity": "sha512-u5/YPJHo1tvkSF2CE0USEkxon82Z5DBy2xR+qfyYNszpX9qcs4sT6uq2kBbj4BXY1+DBGDPnrhMZV3pKWGNukw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
     "@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
@@ -30278,30 +30220,6 @@
       "resolved": "https://registry.npmjs.org/@types/lockfile/-/lockfile-1.0.4.tgz",
       "integrity": "sha512-Q8oFIHJHr+htLrTXN2FuZfg+WXVHQRwU/hC2GpUu+Q8e3FUM9EDkS2pE3R2AO1ZGu56f479ybdMCNF1DAu8cAQ==",
       "dev": true
-    },
-    "@types/lodash": {
-      "version": "4.14.183",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.183.tgz",
-      "integrity": "sha512-UXavyuxzXKMqJPEpFPri6Ku5F9af6ZJXUneHhvQJxavrEjuHkFp2YnDWHcxJiG7hk8ZkWqjcyNeW1s/smZv5cw==",
-      "dev": true
-    },
-    "@types/lodash.debounce": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.9.tgz",
-      "integrity": "sha512-Ma5JcgTREwpLRwMM+XwBR7DaWe96nC38uCBDFKZWbNKD+osjVzdpnUSwBcqCptrp16sSOLBAUb50Car5I0TCsQ==",
-      "dev": true,
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
-    "@types/lodash.noop": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@types/lodash.noop/-/lodash.noop-3.0.9.tgz",
-      "integrity": "sha512-KS47MA78vxE+Stvhpd5QEfNpFgwOmKcZMpT8ATNotTrlWdIxpDDPYCMJgcCFDaXHb2AmKhCu4oFM/2HezwUhGA==",
-      "dev": true,
-      "requires": {
-        "@types/lodash": "*"
-      }
     },
     "@types/mime": {
       "version": "3.0.1",
@@ -38886,18 +38804,14 @@
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "dev": true
     },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
-    },
-    "lodash.noop": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-3.0.1.tgz",
-      "integrity": "sha512-TmYdmu/pebrdTIBDK/FDx9Bmfzs9x0sZG6QIJuMDTqEPfeciLcN13ij+cOd0i9vwJfBtbG9UQ+C7MkXgYxrIJg=="
     },
     "lodash.startcase": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -64,8 +64,6 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "lodash.debounce": "^4.0.8",
-    "lodash.noop": "^3.0.1",
     "path-to-regexp": "^6.3.0",
     "react-sweet-state": "^2.6.4",
     "url-parse": "^1.5.10"
@@ -95,8 +93,6 @@
     "@types/history-5": "npm:@types/history@^5.0.0",
     "@types/jest": "^29.5.12",
     "@types/jscodeshift": "^0.11.11",
-    "@types/lodash.debounce": "^4.0.9",
-    "@types/lodash.noop": "^3.0.9",
     "@types/react": "^18.2.64",
     "@types/react-dom": "^18.2.21",
     "@types/url-parse": "^1.4.11",

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,6 +1,7 @@
-import noop from 'lodash.noop';
-
 import { createLegacyHistory } from './utils/create-legacy-history';
+import { noop } from './utils/noop';
+
+export { noop };
 
 export const DEFAULT_LOCATION = { pathname: '', search: '', hash: '' };
 

--- a/src/common/utils/create-legacy-history/index.ts
+++ b/src/common/utils/create-legacy-history/index.ts
@@ -1,11 +1,27 @@
 import { createPath } from 'history';
-import debounce from 'lodash.debounce';
-import noop from 'lodash.noop';
 
 import { BrowserHistory, Location } from '../../types';
+import { noop } from '../noop';
 
 type HistoryAction = 'POP' | 'PUSH' | 'REPLACE';
 type Listener = (location: Location, action: HistoryAction) => void;
+
+const debounce = <T extends (...args: any[]) => any>(
+  func: T,
+  wait: number
+): ((...args: Parameters<T>) => void) => {
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+
+  return (...args: Parameters<T>) => {
+    if (timeout !== null) {
+      clearTimeout(timeout);
+    }
+    timeout = setTimeout(() => {
+      timeout = null;
+      func(...args);
+    }, wait);
+  };
+};
 
 const hasWindow = () => typeof window !== 'undefined';
 
@@ -82,7 +98,7 @@ const createLegacyListener = (updateExposedLocation: Listener) => {
   }
 
   return (listener: any) => {
-    listeners = listeners.concat(listener);
+    listeners = [...listeners, listener];
 
     return () => {
       listeners = listeners.filter(lst => lst !== listener);

--- a/src/common/utils/match-route/matchPath.ts
+++ b/src/common/utils/match-route/matchPath.ts
@@ -43,7 +43,7 @@ function matchPath(
     sensitive = false,
     basePath = '',
   } = options;
-  const paths = [].concat(basePath + p);
+  const paths = [basePath + p].flat();
 
   return paths.reduce((matched: any, path: any) => {
     if (!path && path !== '') return null;

--- a/src/common/utils/match-route/matchQuery.ts
+++ b/src/common/utils/match-route/matchQuery.ts
@@ -36,7 +36,7 @@ function matchQuery(
       }
 
       /* First check if queryParams contains the relevant param */
-      let match = Object.prototype.hasOwnProperty.call(queryParams, name);
+      let match = Object.hasOwn(queryParams, name);
       /* Save actual value so we expose it as part of match object */
       if (match) {
         queryMatch[name] = queryParams[name] || '';

--- a/src/common/utils/noop.ts
+++ b/src/common/utils/noop.ts
@@ -1,0 +1,1 @@
+export const noop = () => {};

--- a/src/controllers/router-actions/test.tsx
+++ b/src/controllers/router-actions/test.tsx
@@ -1,8 +1,8 @@
 import { render } from '@testing-library/react';
-import noop from 'lodash.noop';
 import React from 'react';
 import { defaultRegistry } from 'react-sweet-state';
 
+import { noop } from '../../common/utils/noop';
 import { Router } from '../router';
 
 import { RouterActions } from './index';

--- a/src/controllers/router-store/test.tsx
+++ b/src/controllers/router-store/test.tsx
@@ -64,11 +64,12 @@ describe('RouterStore', () => {
       return {
         actions: getRouterStore().actions,
         getState: getRouterState,
-        history: Object.assign({}, history, {
+        history: {
+          ...history,
           listen,
           push,
           replace,
-        }),
+        },
         plugins,
       };
     }

--- a/src/resources/__tests__/integration.test.tsx
+++ b/src/resources/__tests__/integration.test.tsx
@@ -29,7 +29,7 @@ describe('<Router /> with resources client-side integration tests', () => {
 
   it('re-triggers requests for timed out resources when mounted', async () => {
     const resolver = (resolveWith: any, delay = 0) =>
-      new Promise(resolve => setTimeout(() => resolve(resolveWith), delay));
+      new Promise(resolve => setTimeout(resolve, delay, resolveWith));
 
     const completedResource = createResource({
       getKey: () => 'key',

--- a/src/resources/controllers/resource-store/test.tsx
+++ b/src/resources/controllers/resource-store/test.tsx
@@ -78,7 +78,7 @@ describe('resource store', () => {
     maxAge: Number.MAX_SAFE_INTEGER,
   });
   const resolver = (resolveWith: any, delay = 0) =>
-    new Promise(resolve => setTimeout(() => resolve(resolveWith), delay));
+    new Promise(resolve => setTimeout(resolve, delay, resolveWith));
 
   const getResourceSlice = (
     t: ResourceType

--- a/src/resources/controllers/resource-store/utils/dependent-resources/index.ts
+++ b/src/resources/controllers/resource-store/utils/dependent-resources/index.ts
@@ -16,8 +16,8 @@ import { getPrefetchSlice, getResourceState } from '../manage-resource-state';
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries
 const fromEntries =
   Object.fromEntries ??
-  (<T>(entries: [string, T][]) =>
-    Object.assign({}, ...entries.map(([k, v]) => ({ [k]: v }))));
+  (<T>(entries: [string, T][]): Record<string, T> =>
+    entries.reduce((acc, [k, v]) => ({ ...acc, [k]: v }), {}));
 
 type MatchableType =
   | { type: ResourceType }

--- a/src/resources/controllers/use-resource/index.ts
+++ b/src/resources/controllers/use-resource/index.ts
@@ -42,7 +42,7 @@ export const useResource = <RouteResourceData extends unknown>(
       >(RouterStore, {
         selector: ({ match, query, route }, keyArg): string =>
           resource.getKey(
-            keyArg != null ? keyArg : { match, query, route },
+            keyArg ?? { match, query, route },
             actions.getContext()
           ),
       }),

--- a/src/ui/link/index.tsx
+++ b/src/ui/link/index.tsx
@@ -63,15 +63,14 @@ const Link = forwardRef<HTMLButtonElement | HTMLAnchorElement, LinkProps>(
       basePath: routerActions.getBasePath(),
     };
     const linkDestination =
-      href != null
-        ? href
-        : typeof to !== 'string'
-          ? (route &&
-              createPath(
-                generateLocationFromPath(route.path, routeAttributes)
-              )) ||
-            ''
-          : to;
+      href ??
+      (typeof to !== 'string'
+        ? (route &&
+            createPath(
+              generateLocationFromPath(route.path, routeAttributes)
+            )) ||
+          ''
+        : to);
     const IS_ABSOLUTE_LINK_REGEX = /^((?:(http|https):\/\/)|\/\/)/;
     const staticBasePath =
       (href != null && !IS_ABSOLUTE_LINK_REGEX.test(href)) ||


### PR DESCRIPTION
https://e18e.dev recently dropped an ESLint Plugin:

> The official e18e ESLint plugin for code modernization and performance best practices - e18e/eslint-plugin
  
I temp upgrade ESLint so I could use the plugin and identify issues and then un-did ESLint upgrades. Happy to do a follow up PR upgrading ESLint to the latest version.

**Dependencies Removed**

- lodash.debounce → Native implementation
- lodash.noop → Native implementation
- @types/lodash.debounce
- @types/lodash.noop

**Code Modernization**

- Spread Syntax 
- Object.hasOwn() 
- Timer Args
- Nullish Coalescing 
- fromEntries polyfill